### PR TITLE
show deprecation warning for .write()

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var Promise = require('bluebird');
+var deprecate = require('util-deprecate');
 var sharp = require('./build/Release/sharp');
 
 var Sharp = function(input) {
@@ -153,7 +154,7 @@ Sharp.prototype.toFile = function(output, callback) {
 };
 
 // Deprecated to make way for future stream support - remove in v0.6.0
-Sharp.prototype.write = Sharp.prototype.toFile;
+Sharp.prototype.write = deprecate(Sharp.prototype.toFile, '.write() is deprecated and will be removed in v0.6.0. Use .toFile() instead.');
 
 Sharp.prototype.toBuffer = function(callback) {
   return this._sharp('__input', callback);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   ],
   "dependencies": {
     "nan": "^1.1.2",
-    "bluebird": "^1.2.4"
+    "bluebird": "^1.2.4",
+    "util-deprecate": "^1.0.0"
   },
   "devDependencies": {
     "imagemagick": "^0.1.3",

--- a/tests/unit.js
+++ b/tests/unit.js
@@ -219,7 +219,7 @@ async.series([
   },
   // Do not enlarge the output if the input width is already less than the output width
   function(done) {
-    sharp(inputJpg).resize(2800).withoutEnlargement().write(outputJpg, function(err) {
+    sharp(inputJpg).resize(2800).withoutEnlargement().toFile(outputJpg, function(err) {
       if (err) throw err;
       imagemagick.identify(outputJpg, function(err, features) {
         if (err) throw err;
@@ -231,7 +231,7 @@ async.series([
   },
   // Do not enlarge the output if the input height is already less than the output height
   function(done) {
-    sharp(inputJpg).resize(null, 2300).withoutEnlargement().write(outputJpg, function(err) {
+    sharp(inputJpg).resize(null, 2300).withoutEnlargement().toFile(outputJpg, function(err) {
       if (err) throw err;
       imagemagick.identify(outputJpg, function(err, features) {
         if (err) throw err;


### PR DESCRIPTION
and actually deprecate `.write()`
