### PR TITLE
remove benchmarks from npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "description": "High performance Node.js module to resize JPEG, PNG and WebP images using the libvips library",
   "scripts": {
-    "test": "node tests/unit && node tests/perf"
+    "test": "node tests/unit"
   },
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
this makes running `npm test` unnecessarily long
