### PR TITLE
Add support for stand-alone, pre-resize, and post-resize extraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,14 @@ var Sharp = function(input) {
     streamIn: false,
     sequentialRead: false,
     // resize options
+    topOffsetPre: -1,
+    leftOffsetPre: -1,
+    widthPre: -1,
+    heightPre: -1,
+    topOffsetPost: -1,
+    leftOffsetPost: -1,
+    widthPost: -1,
+    heightPost: -1,
     width: -1,
     height: -1,
     canvas: 'c',
@@ -99,6 +107,15 @@ Sharp.prototype.crop = function(gravity) {
       throw new Error('Unsupported crop gravity ' + gravity);
     }
   }
+  return this;
+};
+
+Sharp.prototype.extract = function(topOffset, leftOffset, width, height) {
+  var suffix = this.options.width === -1 && this.options.height === -1 ? 'Pre' : 'Post';
+  var values = arguments;
+  ['topOffset', 'leftOffset', 'width', 'height'].forEach(function(name, index) {
+    this.options[name + suffix] = values[index];
+  }.bind(this));
   return this;
 };
 
@@ -239,8 +256,8 @@ Sharp.prototype.compressionLevel = function(compressionLevel) {
 };
 
 Sharp.prototype.withMetadata = function(withMetadata) {
-    this.options.withMetadata = (typeof withMetadata === 'boolean') ? withMetadata : true;
-    return this;
+  this.options.withMetadata = (typeof withMetadata === 'boolean') ? withMetadata : true;
+  return this;
 };
 
 Sharp.prototype.resize = function(width, height) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "Juliano Julio <julianojulio@gmail.com>",
     "Daniel Gasienica <daniel@gasienica.ch>",
     "Julian Walker <julian@fiftythree.com>",
-    "Amit Pitaru <pitaru.amit@gmail.com>"
+    "Amit Pitaru <pitaru.amit@gmail.com>",
+    "Brandon Aaron <hello.brandon@aaron.sh>"
   ],
   "description": "High performance Node.js module to resize JPEG, PNG and WebP images using the libvips library",
   "scripts": {
@@ -30,6 +31,7 @@
     "thumbnail",
     "sharpen",
     "crop",
+    "extract",
     "embed",
     "libvips",
     "vips",

--- a/tests/unit.js
+++ b/tests/unit.js
@@ -563,6 +563,69 @@ async.series([
       done();
     });
   },
+  // Extract jpg
+  function(done) {
+    sharp(inputJpg).extract(2,2,20,20).toFile(path.join(fixturesPath, 'output.extract.jpg'), function(err, info) {
+      if (err) throw err;
+      assert.strictEqual(20, info.width);
+      assert.strictEqual(20, info.height);
+      done();
+    });
+  },
+  // Extract png
+  function(done) {
+    sharp(inputPng).extract(300,200,400,200).toFile(path.join(fixturesPath, 'output.extract.png'), function(err, info) {
+      if (err) throw err;
+      assert.strictEqual(400, info.width);
+      assert.strictEqual(200, info.height);
+      done();
+    });
+  },
+  // Extract webp
+  function(done) {
+    sharp(inputWebP).extract(50, 100, 125, 200).toFile(path.join(fixturesPath, 'output.extract.webp'), function(err, info) {
+      if (err) throw err;
+      assert.strictEqual(125, info.width);
+      assert.strictEqual(200, info.height);
+      done();
+    });
+  },
+  // Extract tiff
+  function(done) {
+    sharp(inputTiff).extract(63, 34, 341, 529).toFile(path.join(fixturesPath, 'output.extract.tiff'), function(err, info) {
+      if (err) throw err;
+      assert.strictEqual(341, info.width);
+      assert.strictEqual(529, info.height);
+      done();
+    });
+  },
+  // Extract before resize
+  function(done) {
+    sharp(inputJpg).extract(10, 10, 10, 500, 500).resize(100, 100).toFile(path.join(fixturesPath, 'output.extract.resize.jpg'), function(err, info) {
+      if (err) throw err;
+      assert.strictEqual(100, info.width);
+      assert.strictEqual(100, info.height);
+      done();
+    });
+  },
+  // Extract after resize and crop
+  function(done) {
+    sharp(inputJpg).resize(500, 500).crop(sharp.gravity.north).extract(10, 10, 100, 100).toFile(path.join(fixturesPath, 'output.resize.crop.extract.jpg'), function(err, info) {
+      if (err) throw err;
+      assert.strictEqual(100, info.width);
+      assert.strictEqual(100, info.height);
+      done();
+    });
+  },
+  // Extract before and after resize and crop
+  function(done) {
+    sharp(inputJpg).extract(0, 0, 700, 700).resize(500, 500).crop(sharp.gravity.north).extract(10, 10, 100, 100).toFile(path.join(fixturesPath, 'output.extract.resize.crop.extract.jpg'), function(err, info) {
+      if (err) throw err;
+      assert.strictEqual(100, info.width);
+      assert.strictEqual(100, info.height);
+      done();
+    });
+  },
   // Keeps Metadata after a resize
   function(done) {
       sharp(inputJpgWithExif).resize(320, 240).withMetadata().toBuffer(function(err, buffer) {


### PR DESCRIPTION
Now rebased onto the alpha branch... I implemented the API (with unit tests) as described in #23 (#23 (comment)). The extract method can be called stand alone or it can be called before and after calling resize. I know that issue is tagged as "work-in-progress" but I didn't see a branch for it and I needed it. My C++ is out of practice at best but I tried to just follow the existing patterns. I don't mind making tweaks or changes if I can make it better.
