### PR TITLE
Pass errors as Error instances rather than strings.

### DIFF
--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -87,7 +87,7 @@ class MetadataWorker : public NanAsyncWorker {
     Handle<Value> argv[2] = { NanNull(), NanNull() };
     if (!baton->err.empty()) {
       // Error
-      argv[0] = NanNew<String>(baton->err.data(), baton->err.size());
+      argv[0] = Exception::Error(NanNew<String>(baton->err.data(), baton->err.size()));
     } else {
       // Metadata Object
       Local<Object> info = NanNew<Object>();

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -185,4 +185,11 @@ describe('Image metadata', function() {
     });
   });
 
+  it('Report an invalid image as an error', function(done) {
+    sharp(new Buffer([0x1, 0x2, 0x3, 0x4])).metadata(function (err, metadata) {
+      assert.ok(err);
+      assert.ok(err instanceof Error);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
http://www.devthought.com/2011/12/22/a-string-is-not-an-error/

All the errors that originate from JavaScript already seem to be Error instances, so this is probably just an oversight in the C++ code.
