### PR TITLE
Do not call g_object_unref when imageType comes out as UNKNOWN.

### DIFF
--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -76,7 +76,9 @@ class MetadataWorker : public NanAsyncWorker {
       }
     }
     // Clean up
-    g_object_unref(image);
+    if (imageType != UNKNOWN) {
+      g_object_unref(image);
+    }
     vips_error_clear();
     vips_thread_shutdown();
   }


### PR DESCRIPTION
Avoids "(sharp:23220): GLib-GObject-CRITICAL **: g_object_unref: assertion 'G_IS_OBJECT (object)' failed" dumped to the console when an unsupported or invalid image is loaded.
