### PR TITLE
:arrow_down: nan@^1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "bluebird": "^2.8.2",
     "color": "^0.7.3",
-    "nan": "^1.6.1",
+    "nan": "^1.5.1",
     "semver": "^4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
1.6 breaks iojs. this lowers the minimum nan version so that developers can still do `nan@~1.5.1`.