### PR TITLE
Change nan dependency back to ^1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "bluebird": "^2.9.3",
     "color": "^0.7.3",
-    "nan": "1.5.3",
+    "nan": "^1.6.2",
     "semver": "^4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The issue with nan on io.js was fixed in https://github.com/rvagg/nan/pull/273. `npm install` on io.js 1.1.0 works now.