### PR TITLE
Let libvips check whether we received a valid image or not

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,24 +73,7 @@ var Sharp = function(input) {
     this.options.fileIn = input;
   } else if (typeof input === 'object' && input instanceof Buffer) {
     // input=buffer
-    if (
-      (input.length > 3) &&
-      // JPEG
-      (input[0] === 0xFF && input[1] === 0xD8) ||
-      // PNG
-      (input[0] === 0x89 && input[1] === 0x50) ||
-      // WebP
-      (input[0] === 0x52 && input[1] === 0x49) ||
-      // TIFF
-      (input[0] === 0x4D && input[1] === 0x4D && input[2] === 0x00 && (input[3] === 0x2A || input[3] === 0x2B)) ||
-      (input[0] === 0x49 && input[1] === 0x49 && (input[2] === 0x2A || input[2] === 0x2B) && input[3] === 0x00) ||
-      // GIF
-      (input[0] === 0x47 && input[1] === 0x49 && input[2] === 0x46 && input[3] === 0x38 && (input[4] === 0x37 || input[4] === 0x39) && input[5] === 0x61)
-    ) {
-      this.options.bufferIn = input;
-    } else {
-      throw new Error('Buffer contains an unsupported image format. JPEG, PNG, WebP, TIFF and GIF are currently supported.');
-    }
+    this.options.bufferIn = input;
   } else {
     // input=stream
     this.options.streamIn = true;

--- a/test/unit/io.js
+++ b/test/unit/io.js
@@ -202,27 +202,23 @@ describe('Input/output', function() {
   });
 
   it('Fail when input is empty Buffer', function(done) {
-    var failed = true;
-    try {
-      sharp(new Buffer(0));
-      failed = false;
-    } catch (err) {
+    sharp(new Buffer(0)).toBuffer().then(function () {
+      assert(false);
+      done();
+    }).catch(function (err) {
       assert(err instanceof Error);
-    }
-    assert(failed);
-    done();
+      done();
+    });
   });
 
   it('Fail when input is invalid Buffer', function(done) {
-    var failed = true;
-    try {
-      sharp(new Buffer([0x1, 0x2, 0x3, 0x4]));
-      failed = false;
-    } catch (err) {
+    sharp(new Buffer([0x1, 0x2, 0x3, 0x4])).toBuffer().then(function () {
+      assert(false);
+      done();
+    }).catch(function (err) {
       assert(err instanceof Error);
-    }
-    assert(failed);
-    done();
+      done();
+    });
   });
 
   it('Promises/A+', function(done) {


### PR DESCRIPTION
This removes the custom image fingerprinting code and uses the libvips
is_a_buffer() infrastructure instead.

This requires https://github.com/jcupitt/libvips/pull/240.