### PR TITLE
Install libgsf-1-dev on Debian 8

### DIFF
--- a/preinstall.sh
+++ b/preinstall.sh
@@ -90,7 +90,7 @@ case $(uname -s) in
         jessie|vivid)
           # Debian 8, Ubuntu 15
           echo "Installing libvips via apt-get"
-          apt-get install -y libvips-dev
+          apt-get install -y libvips-dev libgsf-1-dev
           ;;
         trusty|utopic|qiana|rebecca)
           # Ubuntu 14, Mint 17


### PR DESCRIPTION
This was needed on my docker container running Debian Jessie. This is the error without it:

```text
Package libgsf-1 was not found in the pkg-config search path.
Perhaps you should add the directory containing `libgsf-1.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libgsf-1', required by 'vips', not found
gyp: Call to 'PKG_CONFIG_PATH=":$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/usr/lib/pkgconfig" pkg-config --libs vips' returned exit status 1. while trying to load binding.gyp
```