### PR TITLE
feature: min

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,12 @@ Preserving aspect ratio, resize the image to the maximum `width` or `height` spe
 
 Both `width` and `height` must be provided via `resize` otherwise the behaviour will default to `crop`.
 
+#### min()
+
+Preserving aspect ratio, resize the image to the minimum `width` or `height` specified.
+
+Both `width` and `height` must be provided via `resize` otherwise the behaviour will default to `crop`.
+
 #### background(rgba)
 
 Set the background for the `embed` and `flatten` operations.

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ var Sharp = function(input) {
     heightPost: -1,
     width: -1,
     height: -1,
-    canvas: 'c',
+    canvas: 'crop',
     gravity: 0,
     angle: 0,
     rotateBeforePreExtract: false,
@@ -136,7 +136,7 @@ Sharp.prototype._write = function(chunk, encoding, callback) {
 module.exports.gravity = {'center': 0, 'centre': 0, 'north': 1, 'east': 2, 'south': 3, 'west': 4};
 
 Sharp.prototype.crop = function(gravity) {
-  this.options.canvas = 'c';
+  this.options.canvas = 'crop';
   if (typeof gravity === 'number' && !Number.isNaN(gravity) && gravity >= 0 && gravity <= 4) {
     this.options.gravity = gravity;
   } else {
@@ -176,12 +176,17 @@ Sharp.prototype.background = function(rgba) {
 };
 
 Sharp.prototype.embed = function() {
-  this.options.canvas = 'e';
+  this.options.canvas = 'embed';
   return this;
 };
 
 Sharp.prototype.max = function() {
-  this.options.canvas = 'm';
+  this.options.canvas = 'max';
+  return this;
+};
+
+Sharp.prototype.min = function() {
+  this.options.canvas = 'min';
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "Amit Pitaru <pitaru.amit@gmail.com>",
     "Brandon Aaron <hello.brandon@aaron.sh>",
     "Andreas Lind <andreas@one.com>",
-    "Maurus Cuelenaere <mcuelenaere@gmail.com>"
+    "Maurus Cuelenaere <mcuelenaere@gmail.com>",
+    "Linus Unnebäck <linus@folkdatorn.se>"
   ],
   "description": "High performance Node.js module to resize JPEG, PNG, WebP and TIFF images using the libvips library",
   "scripts": {

--- a/test/unit/resize.js
+++ b/test/unit/resize.js
@@ -185,6 +185,39 @@ describe('Resize dimensions', function() {
     });
   });
 
+  it('Min width or height considering ratio (landscape)', function(done) {
+    sharp(fixtures.inputJpg).resize(320, 320).min().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(392, info.width);
+      assert.strictEqual(320, info.height);
+      done();
+    });
+  });
+
+  it('Min width or height considering ratio (portrait)', function(done) {
+    sharp(fixtures.inputTiff).resize(320, 320).min().jpeg().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(320, info.width);
+      assert.strictEqual(422, info.height);
+      done();
+    });
+  });
+
+  it('Provide only one dimension with min, should default to crop', function(done) {
+    sharp(fixtures.inputJpg).resize(320).min().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(320, info.width);
+      assert.strictEqual(261, info.height);
+      done();
+    });
+  });
+
   it('Do not enlarge when input width is already less than output width', function(done) {
     sharp(fixtures.inputJpg)
       .resize(2800)


### PR DESCRIPTION
*fixes #174*

This add a new feature `.min()` which preserves the aspect ration and resize the image to the minimum `width` or `height` specified.

On another note, we might want to make the documentation for `max()` and `min()` a bit clearer. This is how Mozilla describes the `background-size` values `contain` and `cover`:

> **cover**
> This keyword specifies that the background image should be scaled to be as small as possible while ensuring both its dimensions are greater than or equal to the corresponding dimensions of the background positioning area.

> **contain**
> This keyword specifies that the background image should be scaled to be as large as possible while ensuring both its dimensions are less than or equal to the corresponding dimensions of the background positioning area.

I think that if we draw some inspiration from here we can make it a bit more clear what they do. @lovell?