### PR TITLE
Support resize without preserving aspect ratio

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,6 +185,11 @@ Sharp.prototype.min = function() {
   return this;
 };
 
+Sharp.prototype.ignoreAspectRatio = function() {
+  this.options.canvas = 'ignore_aspect';
+  return this;
+};
+
 Sharp.prototype.flatten = function(flatten) {
   this.options.flatten = (typeof flatten === 'boolean') ? flatten : true;
   return this;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "Andreas Lind <andreas@one.com>",
     "Maurus Cuelenaere <mcuelenaere@gmail.com>",
     "Linus Unnebäck <linus@folkdatorn.se>",
-    "Victor Mateevitsi <mvictoras@gmail.com>"
+    "Victor Mateevitsi <mvictoras@gmail.com>",
+    "Alaric Holloway <alaric.holloway@gmail.com>"
   ],
   "description": "High performance Node.js module to resize JPEG, PNG, WebP and TIFF images using the libvips library",
   "scripts": {

--- a/test/unit/resize.js
+++ b/test/unit/resize.js
@@ -259,5 +259,104 @@ describe('Resize dimensions', function() {
         done();
       });
   });
+  
+  it('Downscale width and height, ignoring aspect ratio', function(done) {
+    sharp(fixtures.inputJpg).resize(320, 320).ignoreAspectRatio().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(320, info.width);
+      assert.strictEqual(320, info.height);
+      done();
+    });
+  });
+  
+  it('Downscale width, ignoring aspect ratio', function(done) {
+    sharp(fixtures.inputJpg).resize(320).ignoreAspectRatio().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(320, info.width);
+      assert.strictEqual(2225, info.height);
+      done();
+    });
+  });
+  
+  it('Downscale height, ignoring aspect ratio', function(done) {
+    sharp(fixtures.inputJpg).resize(null, 320).ignoreAspectRatio().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(2725, info.width);
+      assert.strictEqual(320, info.height);
+      done();
+    });
+  });
+  
+  it('Upscale width and height, ignoring aspect ratio', function(done) {
+    sharp(fixtures.inputJpg).resize(3000, 3000).ignoreAspectRatio().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(3000, info.width);
+      assert.strictEqual(3000, info.height);
+      done();
+    });
+  });
+  
+  it('Upscale width, ignoring aspect ratio', function(done) {
+    sharp(fixtures.inputJpg).resize(3000).ignoreAspectRatio().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(3000, info.width);
+      assert.strictEqual(2225, info.height);
+      done();
+    });
+  });
+  
+  it('Upscale height, ignoring aspect ratio', function(done) {
+    sharp(fixtures.inputJpg).resize(null, 3000).ignoreAspectRatio().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(2725, info.width);
+      assert.strictEqual(3000, info.height);
+      done();
+    });
+  });
+  
+  it('Downscale width, upscale height, ignoring aspect ratio', function(done) {
+    sharp(fixtures.inputJpg).resize(320, 3000).ignoreAspectRatio().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(320, info.width);
+      assert.strictEqual(3000, info.height);
+      done();
+    });
+  });
+  
+  it('Upscale width, downscale height, ignoring aspect ratio', function(done) {
+    sharp(fixtures.inputJpg).resize(3000, 320).ignoreAspectRatio().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(3000, info.width);
+      assert.strictEqual(320, info.height);
+      done();
+    });
+  });
+  
+  it('Identity transform, ignoring aspect ratio', function(done) {
+    sharp(fixtures.inputJpg).ignoreAspectRatio().toBuffer(function(err, data, info) {
+      if (err) throw err;
+      assert.strictEqual(true, data.length > 0);
+      assert.strictEqual('jpeg', info.format);
+      assert.strictEqual(2725, info.width);
+      assert.strictEqual(2225, info.height);
+      done();
+    });
+  });
 
 });


### PR DESCRIPTION
# Goal

Add an `ignoreAspectRatio` method to support resizing of images to arbitrary aspect ratios, as requested in [#118](https://github.com/lovell/sharp/issues/118).

# Behavior

Fixed width and height:

```javascript
sharp('foo.jpg').ignoreAspectRatio().resize(300, 300);
```

Fixed width (leaving height unchanged):

```javascript
sharp('foo.jpg').ignoreAspectRatio().resize(300);
```

Fixed height (leaving width unchanged):

```javascript
sharp('foo.jpg').ignoreAspectRatio().resize(null, 300);
```

sharp's behavior is otherwise unchanged.

# Code paths affected

* src/resize.cc
    - Canvas
        - Additional member `IGNORE_ASPECT`
    - ResizeWorker::Execute
        - Logic is mostly unchanged. Add separate x and y variables for `factor`, `shrink`, and `residual`.
        - Move small amount of logic into private class methods:
            - `CalculateShrink`
            - `CalculateResidual`
        - Use average of `xresidual` and `yresidual` to compute `sigma` for pre-affine-reduction Gaussian blur (see #191).
* index.js
    - New method `Sharp.prototype.ignoreAspectRatio`
        - Sets `this.options.canvas` to "ignore_aspect"
* test/unit/resize.js