### PR TITLE
avoid segfault with unknown interpolator

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -134,6 +134,9 @@ namespace sharp {
   */
   int InterpolatorWindowSize(char const *name) {
     VipsInterpolate *interpolator = vips_interpolate_new(name);
+    if (interpolator == NULL) {
+      return -1;
+    }
     int window_size = vips_interpolate_get_window_size(interpolator);
     g_object_unref(interpolator);
     return window_size;

--- a/src/resize.cc
+++ b/src/resize.cc
@@ -261,6 +261,9 @@ class ResizeWorker : public NanAsyncWorker {
 
     // Get window size of interpolator, used for determining shrink vs affine
     int interpolatorWindowSize = InterpolatorWindowSize(baton->interpolator.c_str());
+    if (InterpolatorWindowSize < 0) {
+      return Error();
+    }
 
     // Scaling calculations
     double xfactor = 1.0;
@@ -510,6 +513,9 @@ class ResizeWorker : public NanAsyncWorker {
       }
       // Create interpolator - "bilinear" (default), "bicubic" or "nohalo"
       VipsInterpolate *interpolator = vips_interpolate_new(baton->interpolator.c_str());
+      if (interpolator == NULL) {
+        return Error();
+      }
       vips_object_local(hook, interpolator);
       // Perform affine transformation
       VipsImage *affined;

--- a/test/unit/interpolation.js
+++ b/test/unit/interpolation.js
@@ -93,4 +93,16 @@ describe('Interpolation', function() {
       });
   });
 
+  it('unknown interpolator throws', function(done) {
+    sharp(fixtures.inputJpg)
+      .resize(320, 240)
+      .interpolateWith('nonexistant')
+      .toBuffer()
+      .catch(function (e) {
+        assert(
+          e.toString().match(/VipsInterpolate: class "nonexistant" not found/)
+        );
+      })
+      .finally(done);
+  });
 });


### PR DESCRIPTION
By accident I called `interpolateWith()` with an unknown interpolator name, which resulted in a segfault.
The attached patch avoids this by checking the return values of `vips_interpolate_new` and raising an exception if this returns NULL.