### PR TITLE
binding.gyp: Fix warnings during compiling

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -74,6 +74,15 @@
       'VCCLCompilerTool': {
         'ExceptionHandling': 1 # /EHsc
       }
-    }
+    },
+    'configurations': {
+      'Release': {
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'ExceptionHandling': 1,
+          }
+        }
+      }
+    },
   }]
 }


### PR DESCRIPTION
Fixes the following warnings while compiling:

```
D:\Forritun\Microsoft Visual Studio 14.0\VC\include\xlocale(341): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc (compiling source file ..\src\common.cc) [D:\sharp\build\sharp.vcxproj]
D:\Forritun\Microsoft Visual Studio 14.0\VC\include\xlocale(341): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc (compiling source file ..\src\operations.cc) [D:\sharp\build\sharp.vcxproj]
...etc...
```

Solution taken from here: https://github.com/TooTallNate/node-gyp/issues/26#issuecomment-7296389