### PR TITLE
crop: Permit specifying the gravity as a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,8 @@ Sharp.prototype.crop = function(gravity) {
   this.options.canvas = 'crop';
   if (typeof gravity === 'number' && !Number.isNaN(gravity) && gravity >= 0 && gravity <= 4) {
     this.options.gravity = gravity;
+  } else if (typeof gravity === 'string' && typeof module.exports.gravity[gravity] === 'number') {
+    this.options.gravity = module.exports.gravity[gravity];
   } else {
     throw new Error('Unsupported crop gravity ' + gravity);
   }

--- a/test/unit/crop.js
+++ b/test/unit/crop.js
@@ -81,10 +81,27 @@ describe('Crop gravities', function() {
       });
   });
 
-  it('Invalid', function() {
+  it('allows specifying the gravity as a string', function(done) {
+    sharp(fixtures.inputJpg)
+      .resize(80, 320)
+      .crop('east')
+      .toBuffer(function(err, data, info) {
+        if (err) throw err;
+        assert.strictEqual(80, info.width);
+        assert.strictEqual(320, info.height);
+        fixtures.assertSimilar(fixtures.expected('gravity-east.jpg'), data, done);
+      });
+  });
+
+  it('Invalid number', function() {
     assert.throws(function() {
       sharp(fixtures.inputJpg).crop(5);
     });
   });
 
+  it('Invalid string', function() {
+    assert.throws(function() {
+      sharp(fixtures.inputJpg).crop('yadda');
+    });
+  });
 });


### PR DESCRIPTION
I have a [use case](https://github.com/papandreou/express-processimage/) where the gravity is taken from a query string and it's cumbersome to use the numeric values or do a lookup in `require('sharp').gravity`. Seemed like it would be easy (and desirable) to support the strings directly.

Will conflict slightly with #205, but it should be easy to resolve.