### PR TITLE
(preinstall) add wily to 'supported' distros

### DIFF
--- a/preinstall.sh
+++ b/preinstall.sh
@@ -125,7 +125,7 @@ if [ $enable_openslide -eq 1 ] && [ -z $vips_with_openslide ] && [ $openslide_ex
     DISTRO=$(lsb_release -c -s)
     echo "Detected Debian Linux '$DISTRO'"
     case "$DISTRO" in
-      jessie|vivid)
+      jessie|vivid|wily)
         # Debian 8, Ubuntu 15
         echo "Installing libopenslide via apt-get"
         apt-get install -y libopenslide-dev
@@ -209,7 +209,7 @@ if [ -f /etc/debian_version ]; then
   DISTRO=$(lsb_release -c -s)
   echo "Detected Debian Linux '$DISTRO'"
   case "$DISTRO" in
-    jessie|vivid)
+    jessie|vivid|wily)
       # Debian 8, Ubuntu 15
       if [ $enable_openslide -eq 1 ]; then
         echo "Recompiling vips with openslide support"


### PR DESCRIPTION
Hey @lovell, similar to my previous _pull request_ here I'm adding `wily` (Ubuntu 15.10) to the list of distros, perhaps as it is still in beta (I'm using Beta 2) this is premature but I can confirm that the preinstall script works perfectly.