### PR TITLE
Add --runtime_link=static

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,9 @@
 {
   'targets': [{
     'target_name': 'sharp',
+    'variables': {
+      'runtime_link%':'shared', 
+    },
     'sources': [
       'src/common.cc',
       'src/metadata.cc',
@@ -51,6 +54,11 @@
             'include_dirs': [
                 '<!(PKG_CONFIG_PATH="<(PKG_CONFIG_PATH)" pkg-config --cflags vips glib-2.0)',
                 '<!(node -e "require(\'nan\')")'
+            ],
+            'conditions': [
+                ['runtime_link == "static"', {
+                  'libraries': ['<!(PKG_CONFIG_PATH="<(PKG_CONFIG_PATH)" pkg-config --libs vips --static)']
+                }]
             ]
         }]
     ],


### PR DESCRIPTION
libvips (https://github.com/jcupitt/libvips/issues/196) use Libs.private, Requires.private options in pkg-config vips.pc files. In case static compiling libvips it is necessary use ```--static``` option with ```pkg-config``` command during compiling sharp. https://github.com/lovell/sharp/issues/169

npm install static example:
```PKG_CONFIG_PATH=/path_to_static_compiled_vips/lib/pkgconfig/ npm install --prefix=/sharp sharp --runtime_link=static```