### PR TITLE
Use libvips-dev apk for alpine-linux packaging test

### DIFF
--- a/packaging/test.sh
+++ b/packaging/test.sh
@@ -51,7 +51,7 @@ fi
 
 # Alpine
 echo "Testing alpine..."
-if docker run -i -t --rm -v $PWD:/v -e "SHARP_TEST_WITHOUT_CACHE=0" alpine:3.3 >packaging/alpine.log 2>&1 sh -c "cd /v; ./packaging/test/alpine.sh; $test";
+if docker run -i -t --rm -v $PWD:/v -e "SHARP_TEST_WITHOUT_CACHE=0" alpine:edge >packaging/alpine.log 2>&1 sh -c "cd /v; ./packaging/test/alpine.sh; $test";
 then echo "alpine OK"
 else echo "alpine fail" && cat packaging/alpine.log
 fi

--- a/packaging/test.sh
+++ b/packaging/test.sh
@@ -51,7 +51,7 @@ fi
 
 # Alpine
 echo "Testing alpine..."
-if docker run -i -t --rm -v $PWD:/v -e "SHARP_TEST_WITHOUT_CACHE=0" wjordan/libvips >packaging/alpine.log 2>&1 sh -c "cd /v; ./packaging/test/alpine.sh; $test";
+if docker run -i -t --rm -v $PWD:/v -e "SHARP_TEST_WITHOUT_CACHE=0" alpine:3.3 >packaging/alpine.log 2>&1 sh -c "cd /v; ./packaging/test/alpine.sh; $test";
 then echo "alpine OK"
 else echo "alpine fail" && cat packaging/alpine.log
 fi

--- a/packaging/test/alpine.sh
+++ b/packaging/test/alpine.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Install Node.js
+# Install build dependencies
 apk add --update make gcc g++ python nodejs
 
-# Install libvips dependencies
-apk add --update glib-dev libpng libwebp libexif libxml2 orc fftw lcms2
+# Install libvips with build headers and dependencies
+apk add libvips-dev --update --repository https://s3.amazonaws.com/wjordan-apk --allow-untrusted


### PR DESCRIPTION
This updates the alpine-linux packaging test to use the libvips-dev apk (currently being served from a custom s3 repository location; see alpinelinux/aports#29 for the upstream APK submission).

I realized that a Docker image probably isn't the most maintainable approach for distributing a compiled-library meant to be used as a base image for other projects, and found it easier to leverage the existing OS package management systems, in this case APKs (which are basically just tar-packages of the project's files, with some metadata). Following the APK conventions, the compiled `libvips` package is separated into `libvips` which is the compiled runtime library, and `libvips-dev` which includes the development headers needed for building projects linking to it. So for a packaging-test for Sharp, we want to link to the `libvips-dev` package.

Note- I've also created a `node-sharp` package which provides a pre-compiled Sharp on Alpine Linux- see alpinelinux/aports#30 for that upstream APK submission.