### PR TITLE
Add libpango1.0-dev for trusty 14.04

### DIFF
--- a/preinstall.sh
+++ b/preinstall.sh
@@ -147,7 +147,7 @@ if [ $enable_openslide -eq 1 ] && [ -z $vips_with_openslide ] && [ $openslide_ex
       trusty|utopic|qiana|rebecca|rafaela|freya)
         # Ubuntu 14, Mint 17
         echo "Installing libopenslide dependencies via apt-get"
-        apt-get install -y automake build-essential curl zlib1g-dev libopenjpeg-dev libpng12-dev libjpeg-dev libtiff5-dev libgdk-pixbuf2.0-dev libxml2-dev libsqlite3-dev libcairo2-dev libglib2.0-dev sqlite3 libsqlite3-dev
+        apt-get install -y automake build-essential curl zlib1g-dev libopenjpeg-dev libpng12-dev libjpeg-dev libtiff5-dev libgdk-pixbuf2.0-dev libxml2-dev libsqlite3-dev libcairo2-dev libglib2.0-dev sqlite3 libsqlite3-dev libpango1.0-dev
         install_libopenslide_from_source
         ;;
       precise|wheezy|maya)


### PR DESCRIPTION
I tried using the script on my my clean 14.04 trusty server, and I had to install libpango1.0-dev again, otherwise the Watermark tests etc would fail. See https://github.com/h2non/bimg/issues/63