### PR TITLE
tweak xcode_settings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -167,6 +167,7 @@
       'CLANG_CXX_LIBRARY': 'libc++',
       'MACOSX_DEPLOYMENT_TARGET': '10.7',
       'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+      'GCC_ENABLE_CPP_RTTI': 'YES',
       'OTHER_CPLUSPLUSFLAGS': [
         '-fexceptions',
         '-Wall',


### PR DESCRIPTION
This allows for a more verbose error message on mac os x
I have no idea why or how but it worked
```
libc++abi.dylib: terminating with uncaught exception of type vips::VError
```
becomes
```
libc++abi.dylib: terminating with uncaught exception of type vips::VError: VipsImage: memory area too small --- should be 1191960 bytes, you passed 1189440
```