### PR TITLE
Add support for writing dz format to zip container

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -527,13 +527,16 @@ The default behaviour, when `withMetadata` is not used, is to strip all metadata
 
 #### tile(options)
 
-The size, overlap and directory layout to use when generating square Deep Zoom image pyramid tiles.
+The size, overlap, container and directory layout to use when generating square Deep Zoom image pyramid tiles.
 
 `options` is an Object with one or more of the following attributes:
 
 * `size` is an integral Number between 1 and 8192. The default value is 256 pixels.
 * `overlap` is an integral Number between 0 and 8192. The default value is 0 pixels.
+* `container` is a String, with value `fs` or `zip`. The default value is `fs`.
 * `layout` is a String, with value `dz`, `zoomify` or `google`. The default value is `dz`.
+
+You can also use the file extension .zip or .szi to write to a ZIP container instead of the filesystem.
 
 ```javascript
 sharp('input.tiff')

--- a/index.js
+++ b/index.js
@@ -660,6 +660,14 @@ Sharp.prototype.tile = function(tile) {
         throw new Error('Invalid tile overlap (0 to 8192) ' + tile.overlap);
       }
     }
+    // Container
+    if (isDefined(tile.container)) {
+      if (isString(tile.container) && contains(tile.container, ['fs', 'zip'])) {
+        this.options.tileContainer = tile.container;
+      } else {
+        throw new Error('Invalid tile container ' + tile.container);
+      }
+    }
     // Layout
     if (isDefined(tile.layout)) {
       if (isString(tile.layout) && contains(tile.layout, ['dz', 'google', 'zoomify'])) {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "async": "^1.5.2",
+    "bufferutil": "^1.2.1",
     "coveralls": "^2.11.9",
     "exif-reader": "^1.0.0",
     "icc": "^0.0.2",
@@ -66,7 +67,7 @@
     "mocha-jshint": "^2.3.1",
     "node-cpplint": "^0.4.0",
     "rimraf": "^2.5.2",
-    "bufferutil": "^1.2.1"
+    "unzip": "^0.1.11"
   },
   "license": "Apache-2.0",
   "config": {

--- a/src/common.cc
+++ b/src/common.cc
@@ -52,6 +52,9 @@ namespace sharp {
   bool IsDz(std::string const &str) {
     return EndsWith(str, ".dzi") || EndsWith(str, ".DZI");
   }
+  bool IsDzZip(std::string const &str) {
+    return EndsWith(str, ".zip") || EndsWith(str, ".ZIP") || EndsWith(str, ".szi") || EndsWith(str, ".SZI");
+  }
 
   /*
     Provide a string identifier for the given image type.

--- a/src/common.h
+++ b/src/common.h
@@ -35,6 +35,7 @@ namespace sharp {
   bool IsWebp(std::string const &str);
   bool IsTiff(std::string const &str);
   bool IsDz(std::string const &str);
+  bool IsDzZip(std::string const &str);
 
   /*
     Provide a string identifier for the given image type.

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -81,6 +81,7 @@ struct PipelineBaton {
   int withMetadataOrientation;
   int tileSize;
   int tileOverlap;
+  VipsForeignDzContainer tileContainer;
   VipsForeignDzLayout tileLayout;
 
   PipelineBaton():
@@ -130,6 +131,7 @@ struct PipelineBaton {
     withMetadataOrientation(-1),
     tileSize(256),
     tileOverlap(0),
+    tileContainer(VIPS_FOREIGN_DZ_CONTAINER_FS),
     tileLayout(VIPS_FOREIGN_DZ_LAYOUT_DZ) {
       background[0] = 0.0;
       background[1] = 0.0;


### PR DESCRIPTION
This adds support for the `container` option of `vips dzsave`, which writes all generated deep zoom files to a ZIP container instead of the filesystem.

To enable it you can either use the `.zip`/ `.szi` file extensions or use `.tile({container: 'zip'})` with `.toFormat('dz')` or the `.dzi` extension.

My original idea was to also implement writing the dz format to a buffer using the ZIP container, but it's currently not possible, because Vips lacks the required `dzsave_buffer` function (see jcupitt/libvips#415).