### PR TITLE
Support for saving lossless WebP

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ var Sharp = function(input, options) {
     formatOut: 'input',
     fileOut: '',
     progressive: false,
+    lossless: false,
     quality: 80,
     compressionLevel: 6,
     withoutAdaptiveFiltering: false,
@@ -807,8 +808,19 @@ Sharp.prototype.png = function() {
 /*
   Force WebP output
 */
-Sharp.prototype.webp = function() {
+Sharp.prototype.webp = function(options) {
   this.options.formatOut = 'webp';
+
+  if (isObject(options)) {
+    if (isDefined(options.lossless)) {
+      if (isBoolean(options.lossless)) {
+        this.options.lossless = options.lossless;
+      } else {
+        throw new Error('Non-boolean value for lossless');
+      }
+    }
+  }
+
   return this;
 };
 

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -734,6 +734,7 @@ class PipelineWorker : public AsyncWorker {
           // Write WEBP to buffer
           VipsArea *area = VIPS_AREA(image.webpsave_buffer(VImage::option()
             ->set("strip", !baton->withMetadata)
+            ->set("lossless", baton->lossless)
             ->set("Q", baton->quality)
           ));
           baton->bufferOut = static_cast<char*>(area->data);
@@ -805,6 +806,7 @@ class PipelineWorker : public AsyncWorker {
           // Write WEBP to file
           image.webpsave(const_cast<char*>(baton->fileOut.data()), VImage::option()
             ->set("strip", !baton->withMetadata)
+            ->set("lossless", baton->lossless)
             ->set("Q", baton->quality)
           );
           baton->formatOut = "webp";
@@ -1080,6 +1082,7 @@ NAN_METHOD(pipeline) {
   baton->extendRight = attrAs<int32_t>(options, "extendRight");
   // Output options
   baton->progressive = attrAs<bool>(options, "progressive");
+  baton->lossless = attrAs<bool>(options, "lossless");
   baton->quality = attrAs<int32_t>(options, "quality");
   baton->compressionLevel = attrAs<int32_t>(options, "compressionLevel");
   baton->withoutAdaptiveFiltering = attrAs<bool>(options, "withoutAdaptiveFiltering");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -69,6 +69,7 @@ struct PipelineBaton {
   bool progressive;
   bool withoutEnlargement;
   VipsAccess accessMethod;
+  bool lossless;
   int quality;
   int compressionLevel;
   bool withoutAdaptiveFiltering;
@@ -120,6 +121,7 @@ struct PipelineBaton {
     extendRight(0),
     progressive(false),
     withoutEnlargement(false),
+    lossless(false),
     quality(80),
     compressionLevel(6),
     withoutAdaptiveFiltering(false),


### PR DESCRIPTION
Hello. :)

This PR adds initial support for saving lossless WebP.

Sharp usually saves WebP in lossy mode with a default quality of 80.
A bug that was fixed in libvips 8.3 means lossless WebP output is now possible.

To enable this in sharp, I've introduced an options object parameter to the webp method. e.g.

```javascript
var image = sharp('file.png')
  .webp({ lossless: true });
```

I'd be happy to make changes to the API—please just let me know.

Also, I haven't added test cases since my test environment isn't working quite right. Once I've got that worked out—any thoughts on the kinds of tests you would like to see?

### Todo

- [ ] extra options parameter for `toFormat()` and other methods?
- [ ] unit tests
- [ ] documentation?

### Example image output

#### PNG (lossless)
![image](https://cloud.githubusercontent.com/assets/21532/14459594/325bc1c6-00fc-11e6-9c4b-234786d5788a.png)

---

#### WebP (lossy - quality:80)
![image](https://cloud.githubusercontent.com/assets/21532/14459611/44bb4e7c-00fc-11e6-82b7-2cbaba3d30e3.png)

---

#### WebP (lossless)
![image](https://cloud.githubusercontent.com/assets/21532/14459622/4fcd95f4-00fc-11e6-8f1e-5ba58dd75ef8.png)
