### PR TITLE
Enable vips GIF loader

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -70,6 +70,7 @@ namespace sharp {
       case ImageType::OPENSLIDE: id = "openslide"; break;
       case ImageType::PPM: id = "ppm"; break;
       case ImageType::FITS: id = "fits"; break;
+      case ImageType::GIF: id = "gif"; break;
       case ImageType::RAW: id = "raw"; break;
       case ImageType::UNKNOWN: id = "unknown"; break;
     }
@@ -121,6 +122,8 @@ namespace sharp {
         imageType = ImageType::PPM;
       } else if (EndsWith(loader, "Fits")) {
         imageType = ImageType::FITS;
+      } else if (EndsWith(loader, "GifFile")) {
+        imageType = ImageType::GIF;
       } else if (EndsWith(loader, "Magick") || EndsWith(loader, "MagickFile")) {
         imageType = ImageType::MAGICK;
       }

--- a/src/common.h
+++ b/src/common.h
@@ -20,6 +20,7 @@ namespace sharp {
     OPENSLIDE,
     PPM,
     FITS,
+    GIF,
     RAW
   };
 


### PR DESCRIPTION
i have noticed that gif file format already supported in vips library and has a vips foreign loader without image magick but it is not enabled because it is not defined as an image type i defined it and it working now :)