### PR TITLE
Adds the option of tiling/replicatng the overlay image across the image.

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ var Sharp = function(input, options) {
     overlayFileIn: '',
     overlayBufferIn: null,
     overlayGravity: 0,
+    overlayTile: false,
     // output options
     formatOut: 'input',
     fileOut: '',
@@ -354,6 +355,15 @@ Sharp.prototype.overlayWith = function(overlay, options) {
     throw new Error('Unsupported overlay ' + typeof overlay);
   }
   if (isObject(options)) {
+    if (typeof options.tile === 'undefined') {
+      this.options.overlayTile = false;
+    }
+    else if (isBoolean(options.tile)) {
+      this.options.overlayTile = options.tile;
+    } else {
+      throw new Error(' Invalid Value for tile ' + options.tile + 'Only Boolean Values allowed for overlay.tile.');
+    }
+    
     if (isInteger(options.gravity) && inRange(options.gravity, 0, 8)) {
       this.options.overlayGravity = options.gravity;
     } else if (isString(options.gravity) && isInteger(module.exports.gravity[options.gravity])) {

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -657,6 +657,21 @@ class PipelineWorker : public AsyncWorker {
         if (overlayImageType == ImageType::UNKNOWN) {
           return Error();
         }
+        // Check if overlay is tiled
+        if (baton->overlayTile) {
+          int overlayImageWidth = overlayImage.width();
+          int overlayImageHeight = overlayImage.height();
+          int across = 0;
+          int down = 0;
+
+          if(overlayImageWidth <= baton->width){
+            across = static_cast<int>(floor(static_cast<double>(baton->width) / overlayImageWidth));
+          }
+          if(overlayImageHeight <= baton->height){
+            down = static_cast<int>(floor(static_cast<double>(baton->height) / overlayImageHeight));
+          }
+          overlayImage = overlayImage.replicate(across, down);
+        }
         // Ensure overlay is premultiplied sRGB
         overlayImage = overlayImage.colourspace(VIPS_INTERPRETATION_sRGB).premultiply();
         // Composite images with given gravity
@@ -1043,6 +1058,7 @@ NAN_METHOD(pipeline) {
     baton->overlayBufferIn = node::Buffer::Data(overlayBufferIn);
   }
   baton->overlayGravity = attrAs<int32_t>(options, "overlayGravity");
+  baton->overlayTile = attrAs<bool>(options, "overlayTile");
   // Resize options
   baton->withoutEnlargement = attrAs<bool>(options, "withoutEnlargement");
   baton->crop = attrAs<int32_t>(options, "crop");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -33,6 +33,7 @@ struct PipelineBaton {
   char *overlayBufferIn;
   size_t overlayBufferInLength;
   int overlayGravity;
+  bool overlayTile;
   int topOffsetPre;
   int leftOffsetPre;
   int widthPre;
@@ -97,6 +98,7 @@ struct PipelineBaton {
     bufferOutLength(0),
     overlayBufferInLength(0),
     overlayGravity(0),
+    overlayTile(false),
     topOffsetPre(-1),
     topOffsetPost(-1),
     channels(0),


### PR DESCRIPTION
USAGE: .overlayWith(overlayimage.png, { tile: true} )