### PR TITLE
Document undocumented BC break in v0.14.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -106,6 +106,10 @@ Requires libvips v8.2.3
   [#387](https://github.com/lovell/sharp/issues/387)
   [@kleisauke](https://github.com/kleisauke)
 
+* Remove deprecated style of calling extract API. Breaks calls using positional arguments.
+  [#276](https://github.com/lovell/sharp/issues/276)
+  [@papandreou](https://github.com/papandreou)
+
 ### v0.13 - "*mind*"
 
 Requires libvips v8.2.2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -108,7 +108,6 @@ Requires libvips v8.2.3
 
 * Remove deprecated style of calling extract API. Breaks calls using positional arguments.
   [#276](https://github.com/lovell/sharp/issues/276)
-  [@papandreou](https://github.com/papandreou)
 
 ### v0.13 - "*mind*"
 


### PR DESCRIPTION
Deprecated style of calling extract was removed in 2034efcf558bbb0a6936b1804c0422103d43ad69