### PR TITLE
Change the order of operations: boolean, extractChannel, then sRGB conversion

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -774,20 +774,6 @@ class PipelineWorker : public AsyncWorker {
         image = Normalize(image);
       }
 
-      // Convert image to sRGB, if not already
-      if (Is16Bit(image.interpretation())) {
-        image = image.cast(VIPS_FORMAT_USHORT);
-      }
-      if (image.interpretation() != VIPS_INTERPRETATION_sRGB) {
-        image = image.colourspace(VIPS_INTERPRETATION_sRGB);
-        // Transform colours from embedded profile to sRGB profile
-        if (baton->withMetadata && HasProfile(image)) {
-          image = image.icc_transform(const_cast<char*>(srgbProfile.data()), VImage::option()
-            ->set("embedded", TRUE)
-          );
-        }
-      }
-
       // Apply bitwise boolean operation between images
       if (baton->booleanOp != VIPS_OPERATION_BOOLEAN_LAST &&
           (baton->booleanBufferInLength > 0 || !baton->booleanFileIn.empty())) {
@@ -838,6 +824,20 @@ class PipelineWorker : public AsyncWorker {
           return Error();
         }
         image = image.extract_band(baton->extractChannel);
+      }
+
+      // Convert image to sRGB, if not already
+      if (Is16Bit(image.interpretation())) {
+        image = image.cast(VIPS_FORMAT_USHORT);
+      }
+      if (image.interpretation() != VIPS_INTERPRETATION_sRGB) {
+        image = image.colourspace(VIPS_INTERPRETATION_sRGB);
+        // Transform colours from embedded profile to sRGB profile
+        if (baton->withMetadata && HasProfile(image)) {
+          image = image.icc_transform(const_cast<char*>(srgbProfile.data()), VImage::option()
+            ->set("embedded", TRUE)
+          );
+        }
       }
 
       // Override EXIF Orientation tag

--- a/test/unit/extractChannel.js
+++ b/test/unit/extractChannel.js
@@ -69,4 +69,13 @@ describe('Image channel extraction', function() {
     });
   });
 
+  it('Non-existant channel', function(done) {
+    sharp(fixtures.inputPng)
+      .extractChannel(1)
+      .toBuffer(function(err) {
+        assert(err instanceof Error);
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
This small pr moves the `boolean()`, `bandbool()`, and `extractChannel()` operations to before the code that performs sRGB conversion. It doesn't make sense to be able to extract a channel that doesn't appear in the input image. It also doesn't make a lot of sense to perform boolean operations on channels that were implicitly added after the image was loaded. This does raise the somewhat odd potential for colorspace conversion to be performed after a bitwise boolean operation -- perhaps this should be explicitly prevented? It can happen if the input image has a non-sRGB profile.