### PR TITLE
Make sure bandbool does not create 1-channel 'sRGB' images

### DIFF
--- a/src/operations.cc
+++ b/src/operations.cc
@@ -396,7 +396,8 @@ namespace sharp {
     Perform boolean/bitwise operation on image color channels - results in one channel image
   */
   VImage Bandbool(VImage image, VipsOperationBoolean const boolean) {
-    return image.bandbool(boolean);
+    image = image.bandbool(boolean);
+    return image.copy(VImage::option()->set("interpretation", VIPS_INTERPRETATION_B_W));
   }
 
   /*

--- a/test/unit/bandbool.js
+++ b/test/unit/bandbool.js
@@ -16,14 +16,25 @@ describe('Bandbool per-channel boolean operations', function() {
       sharp(fixtures.inputPngBooleanNoAlpha)
         .bandbool(op)
         .toBuffer(function(err, data, info) {
+          // should use .toColourspace('b-w') here to get 1 channel output, when it is merged
           if (err) throw err;
           assert.strictEqual(200, info.width);
           assert.strictEqual(200, info.height);
-          assert.strictEqual(1, info.channels);
+          //assert.strictEqual(1, info.channels);
+          assert.strictEqual(3, info.channels);
           fixtures.assertSimilar(fixtures.expected('bandbool_' + op + '_result.png'), data, done);
         });
     });
   });
+
+  it('sRGB image retains 3 channels', function(done) {
+    sharp(fixtures.inputJpg)
+      .bandbool('and')
+      .toBuffer(function(err, data, info) {
+        assert.strictEqual(3, info.channels);
+        done();
+      });
+  });          
 
   it('Invalid operation', function() {
     assert.throws(function() {


### PR DESCRIPTION
This small PR fixes a bug where `bandbool()` produces a 1-channel sRGB image. Without `toColourspace()` there should be no way to get a 1-channel image out of sharp. I've added a test case for this and modified the existing test cases to accept 3-channel images until `toColourspace` can be merged.