### PR TITLE
Return an error message when overlay file is not found or of wrong type

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -697,6 +697,7 @@ class PipelineWorker : public AsyncWorker {
           }
         }
         if (overlayImageType == ImageType::UNKNOWN) {
+          (baton->err).append("Overlay file type is unknown");
           return Error();
         }
         // Check if overlay is tiled

--- a/test/unit/overlay.js
+++ b/test/unit/overlay.js
@@ -528,4 +528,12 @@ describe('Overlays', function() {
       });
   });
 
+  it('Throws an error when called with an invalid file', function(done) {
+    sharp(fixtures.inputJpg).overlayWith('notfound.png')
+      .toBuffer(function(err) {
+        assert(err instanceof Error);
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
The tiny PR ensures that sharp returns an error message when `overlayWith()` is called with an invalid file.