### PR TITLE
Allow overlayWith source without an alpha channel #506

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "Chintan Thakkar <lemnisk8@gmail.com>",
     "F. Orlando Galashan <frulo@gmx.de>",
     "Kleis Auke Wolthuizen <info@kleisauke.nl>",
-    "Matt Hirsch <mhirsch@media.mit.edu>"
+    "Matt Hirsch <mhirsch@media.mit.edu>",
+    "Matthias Thoemmes <thoemmes@gmail.com>"
   ],
   "description": "High performance Node.js image processing, the fastest module to resize JPEG, PNG, WebP and TIFF images",
   "scripts": {

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -583,14 +583,14 @@ class PipelineWorker : public Nan::AsyncWorker {
         } else {
           // Ensure overlay has alpha channel
           if (!HasAlpha(overlayImage)) {
-            double const multiplier = Is16Bit(overlayImage.interpretation()) ? 256.0 : 1.0;
+            double const multiplier = sharp::Is16Bit(overlayImage.interpretation()) ? 256.0 : 1.0;
             overlayImage = overlayImage.bandjoin(
               VImage::new_matrix(overlayImage.width(), overlayImage.height()).new_from_image(255 * multiplier)
             );
           }
           // Ensure image has alpha channel
           if (!HasAlpha(image)) {
-            double const multiplier = Is16Bit(image.interpretation()) ? 256.0 : 1.0;
+            double const multiplier = sharp::Is16Bit(image.interpretation()) ? 256.0 : 1.0;
             image = image.bandjoin(
               VImage::new_matrix(image.width(), image.height()).new_from_image(255 * multiplier)
             );

--- a/test/unit/overlay.js
+++ b/test/unit/overlay.js
@@ -154,11 +154,20 @@ describe('Overlays', function() {
     });
   }
 
-  it('Fail when overlay does not contain alpha channel', function(done) {
+  it('Composite JPEG onto PNG', function(done) {
     sharp(fixtures.inputPngOverlayLayer1)
-      .overlayWith(fixtures.inputJpg)
+      .overlayWith(fixtures.inputJpgWithLandscapeExif1)
       .toBuffer(function(error) {
-        assert.strictEqual(true, error instanceof Error);
+        if (error) return done(error);
+        done();
+      });
+  });
+
+  it('Composite opaque JPEG onto JPEG', function(done) {
+    sharp(fixtures.inputJpg)
+      .overlayWith(fixtures.inputJpgWithLandscapeExif1)
+      .toBuffer(function(error) {
+        if (error) return done(error);
         done();
       });
   });


### PR DESCRIPTION
These changes allow to composite opaque images, applying the commit @strarsis has mentioned.

