### PR TITLE
WebP advanced output options

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -626,6 +626,23 @@ The output quality to use for lossy JPEG, WebP and TIFF output formats. The defa
 
 `quality` is a Number between 1 and 100.
 
+#### alphaQuality(alphaQuality)
+
+The output quality to use for the alpha channel of WebP output formats. The default quality is `100`.
+
+`alphaQuality` is a Number between 1 and 100.
+
+#### lossless(lossless)
+
+Set the use off lossless output of WebP output formats. The default quality is `false`.
+
+`lossless` is ais a boolean where `true` enables and `false` disables lossless output.
+
+#### nearLossless(nearLossless)
+
+Enable preprocessing on lossy compression of WebP formats to increase compression by up to 50%.
+
+
 #### progressive()
 
 Use progressive (interlace) scan for JPEG and PNG output. This typically reduces compression performance by 30% but results in an image that can be rendered sooner when decompressed.

--- a/docs/api.md
+++ b/docs/api.md
@@ -642,6 +642,7 @@ Set the use off lossless output of WebP output formats. The default quality is `
 
 Enable preprocessing on lossy compression of WebP formats to increase compression by up to 50%.
 
+`nearLossless` is a boolean where `true` enables and `false` disables near lossless output.
 
 #### progressive()
 

--- a/index.js
+++ b/index.js
@@ -98,6 +98,9 @@ var Sharp = function(input, options) {
     fileOut: '',
     progressive: false,
     quality: 80,
+    alphaQuality: 100,
+    lossless: false,
+    nearLossless: false,
     compressionLevel: 6,
     withoutAdaptiveFiltering: false,
     withoutChromaSubsampling: false,
@@ -676,6 +679,25 @@ Sharp.prototype.quality = function(quality) {
   } else {
     throw new Error('Invalid quality (1 to 100) ' + quality);
   }
+  return this;
+};
+
+Sharp.prototype.alphaQuality = function(alphaQuality) {
+  if (isInteger(alphaQuality) && inRange(alphaQuality, 1, 100)) {
+    this.options.alphaQuality = alphaQuality;
+  } else {
+    throw new Error('Invalid alphaQuality (1 to 100) ' + alphaQuality);
+  }
+  return this;
+};
+
+Sharp.prototype.lossless = function(lossless) {
+  this.options.lossless = isBoolean(lossless) ? lossless : true;
+  return this;
+};
+
+Sharp.prototype.nearLossless = function(nearLossless) {
+  this.options.nearLossless = isBoolean(nearLossless) ? nearLossless : true;
   return this;
 };
 

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -744,6 +744,9 @@ class PipelineWorker : public Nan::AsyncWorker {
           VipsArea *area = VIPS_AREA(image.webpsave_buffer(VImage::option()
             ->set("strip", !baton->withMetadata)
             ->set("Q", baton->quality)
+            ->set("lossless", baton->lossless )
+            ->set("near_lossless", baton->nearLossless)
+            ->set("alpha_q", baton->alphaQuality)
           ));
           baton->bufferOut = static_cast<char*>(area->data);
           baton->bufferOutLength = area->length;
@@ -1115,6 +1118,9 @@ NAN_METHOD(pipeline) {
   // Output options
   baton->progressive = AttrTo<bool>(options, "progressive");
   baton->quality = AttrTo<int32_t>(options, "quality");
+  baton->alphaQuality = AttrTo<int32_t>(options, "alphaQuality");
+  baton->lossless = AttrTo<bool>(options, "lossless");
+  baton->nearLossless = AttrTo<bool>(options, "nearLossless");
   baton->compressionLevel = AttrTo<int32_t>(options, "compressionLevel");
   baton->withoutAdaptiveFiltering = AttrTo<bool>(options, "withoutAdaptiveFiltering");
   baton->withoutChromaSubsampling = AttrTo<bool>(options, "withoutChromaSubsampling");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -73,6 +73,9 @@ struct PipelineBaton {
   bool withoutEnlargement;
   VipsAccess accessMethod;
   int quality;
+  int alphaQuality;
+  bool lossless;
+  bool nearLossless;
   int compressionLevel;
   bool withoutAdaptiveFiltering;
   bool withoutChromaSubsampling;
@@ -134,6 +137,9 @@ struct PipelineBaton {
     progressive(false),
     withoutEnlargement(false),
     quality(80),
+    alphaQuality(100),
+    lossless(false),
+    nearLossless(false),
     compressionLevel(6),
     withoutAdaptiveFiltering(false),
     withoutChromaSubsampling(false),

--- a/test/unit/io.js
+++ b/test/unit/io.js
@@ -384,6 +384,21 @@ describe('Input/output', function() {
           done();
         });
     });
+
+    it('WebP alpha compression', function(done) {
+      sharp(fixtures.inputPngWithGreyAlpha).toFormat(sharp.format.webp).quality(90).alphaQuality(100).toBuffer(function(err, buffer100) {
+        if (err) throw err;
+        sharp(fixtures.inputPngWithGreyAlpha).toFormat(sharp.format.webp).quality(90).alphaQuality(80).toBuffer(function(err, buffer80) {
+          if (err) throw err;
+          sharp(fixtures.inputPngWithGreyAlpha).toFormat(sharp.format.webp).quality(90).alphaQuality(60).toBuffer(function(err, buffer60) {
+            if (err) throw err;
+            assert(buffer80.length < buffer100.length);
+            assert(buffer60.length < buffer80.length);
+            done();
+          });
+        });
+      });
+    });
   }
 
   it('Invalid output format', function(done) {


### PR DESCRIPTION
Please see this pull request for three additional WebP output option: lossless, alpha_q and near_lossless. See http://www.vips.ecs.soton.ac.uk/supported/8.3/doc/html/libvips/VipsForeignSave.html#vips-webpsave-buffer

I am having trouble getting near_lossless and alpha_q working

```
vips warning: webpsave_buffer: no property named `near_lossless'
vips warning: webpsave_buffer: no property named `alpha_q'
```

The version of libvips downloaded is 8.3.3 so I'm not sure why these are not working - any advice?

I have added documentation and a simple unit test for alpha_q, which should pass when this property can be set. I'll add unit tests for the other parameters after.
