### PR TITLE
Use node-pre-gyp to publish binaries for windows (fixes #186)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ build: off
 platform: x64
 environment:
   VIPS_WARNING: 0
+  node_pre_gyp_accessKeyId:
+    secure: FZqYCWy6PGfdCY6lUMMwurrstrVJWFl+0a4mSas/JZo=
+  node_pre_gyp_secretAccessKey:
+    secure: x961+zy88oXOB9rM+uT0gzjy+2ToB699qDVwf6HTsENsiOTdFMT6I3tCbzWiLI+0
   matrix:
   - nodejs_version: "0.12"
   - nodejs_version: "4"
@@ -11,6 +15,10 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - npm install -g npm@latest
-  - npm install
+  - npm install --build-from-source
 test_script:
   - npm run-script test-win
+on_success:
+  - .\node_modules\.bin\node-pre-gyp package
+  - SET CM=%APPVEYOR_REPO_COMMIT_MESSAGE%
+  - if not "%CM%" == "%CM:[publish binary]=%" .\node_modules\.bin\node-pre-gyp --msvs_version=2013 publish

--- a/package.json
+++ b/package.json
@@ -32,11 +32,19 @@
   "description": "High performance Node.js image processing, the fastest module to resize JPEG, PNG, WebP and TIFF images",
   "scripts": {
     "clean": "rm -rf node_modules/ build/ include/ lib/ coverage/ test/fixtures/output.*",
+    "preinstall": "npm install node-pre-gyp",
+    "install": "node-pre-gyp install --fallback-to-build",
     "test": "VIPS_WARNING=0 node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- --slow=5000 --timeout=30000 ./test/unit/*.js",
     "test-win": "node ./node_modules/mocha/bin/mocha --slow=5000 --timeout=60000 ./test/unit/*.js",
     "test-leak": "./test/leak/leak.sh",
     "test-packaging": "./packaging/test-linux-x64.sh",
     "test-clean": "rm -rf coverage/ test/fixtures/output.* && npm install && npm test"
+  },
+  "binary": {
+    "module_name" : "sharp",
+    "module_path" : "./build/{configuration}/",
+    "remote_path" : "./{module_name}/v{version}/{configuration}/",
+    "host"        : "https://kondi-sharp.s3.amazonaws.com"
   },
   "main": "index.js",
   "repository": {
@@ -62,12 +70,14 @@
     "bluebird": "^3.4.1",
     "color": "^0.11.3",
     "nan": "^2.4.0",
-    "semver": "^5.3.0",
+    "node-pre-gyp": "^0.6.30",
     "request": "^2.74.0",
+    "semver": "^5.3.0",
     "tar": "^2.2.1"
   },
   "devDependencies": {
     "async": "^2.0.1",
+    "aws-sdk": "^2.6.6",
     "bufferutil": "^1.2.1",
     "coveralls": "^2.11.12",
     "exif-reader": "^1.0.1",


### PR DESCRIPTION
This solution only works on windows because on windows the `./build/Release` folder contains all the required binary dependencies. On linux and osx the `./lib` folder is required as well, but they are excluded from the node-pre-gyp precompiled binary package. We might want to move the logic which prepares the `./lib` folder from the `binding.gyp` file to a preinstall script. Would not be so complicates as some part is already in `binding.js` file.

However I think the binary precompilation is much more important on windows than on linux. This is already a big a improvement in my opinion.

I have updated to `appveyor.yml` configuration to automatically publish the precompiled binary when the commit message contains the `"[publish binary]"` string. 
### Important notes

In [my branch](/kondi/sharp/tree/node-pre-gyp) I am using my S3 bucket (kondi-sharp) and my encrypted keys to upload the binaries. You have to change the bucket in [package.json binary/host entry](/kondi/sharp/blob/node-pre-gyp/package.json#L47) and update the [keys in appveyor.yml file](/kondi/sharp/blob/node-pre-gyp/appveyor.yml#L7-L10). More details here: [Create an S3 bucket](/mapbox/node-pre-gyp#1-create-an-s3-bucket) and [Create secure appveyor variables](/mapbox/node-pre-gyp#4-create-secure-variables). If you do not update these, the `[publish binary]` builds will fail on your AppVeyor account because the encryption is unique per project instance.
