### PR TITLE
propagate format to tile output

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -285,7 +285,15 @@ const tile = function tile (tile) {
       }
     }
   }
-  return this;
+  // Format
+  if (is.defined(this.options.formatOut) && is.string(this.options.formatOut)) {
+    if (is.inArray(this.options.formatOut, ['jpeg', 'png', 'webp'])) {
+      this.options.tileFormat = this.options.formatOut;
+    } else if (this.options.formatOut !== 'input') {
+      throw new Error('Invalid tile format ' + this.options.formatOut);
+    }
+  }
+  return this._updateFormatOut('dz');
 };
 
 /**

--- a/lib/output.js
+++ b/lib/output.js
@@ -286,12 +286,10 @@ const tile = function tile (tile) {
     }
   }
   // Format
-  if (is.defined(this.options.formatOut) && is.string(this.options.formatOut)) {
-    if (is.inArray(this.options.formatOut, ['jpeg', 'png', 'webp'])) {
-      this.options.tileFormat = this.options.formatOut;
-    } else if (this.options.formatOut !== 'input') {
-      throw new Error('Invalid tile format ' + this.options.formatOut);
-    }
+  if (is.inArray(this.options.formatOut, ['jpeg', 'png', 'webp'])) {
+    this.options.tileFormat = this.options.formatOut;
+  } else if (this.options.formatOut !== 'input') {
+    throw new Error('Invalid tile format ' + this.options.formatOut);
   }
   return this._updateFormatOut('dz');
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "F. Orlando Galashan <frulo@gmx.de>",
     "Kleis Auke Wolthuizen <info@kleisauke.nl>",
     "Matt Hirsch <mhirsch@media.mit.edu>",
-    "Matthias Thoemmes <thoemmes@gmail.com>"
+    "Matthias Thoemmes <thoemmes@gmail.com>",
+    "Patrick Paskaris <patrick@paskaris.gr>"
   ],
   "scripts": {
     "clean": "rm -rf node_modules/ build/ vendor/ coverage/ test/fixtures/output.*",

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -167,8 +167,7 @@ struct PipelineBaton {
     tileSize(256),
     tileOverlap(0),
     tileContainer(VIPS_FOREIGN_DZ_CONTAINER_FS),
-    tileLayout(VIPS_FOREIGN_DZ_LAYOUT_DZ),
-    tileFormat("jpeg") {
+    tileLayout(VIPS_FOREIGN_DZ_LAYOUT_DZ) {
       background[0] = 0.0;
       background[1] = 0.0;
       background[2] = 0.0;

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -102,6 +102,7 @@ struct PipelineBaton {
   int tileOverlap;
   VipsForeignDzContainer tileContainer;
   VipsForeignDzLayout tileLayout;
+  std::string tileFormat;
 
   PipelineBaton():
     input(nullptr),
@@ -166,7 +167,8 @@ struct PipelineBaton {
     tileSize(256),
     tileOverlap(0),
     tileContainer(VIPS_FOREIGN_DZ_CONTAINER_FS),
-    tileLayout(VIPS_FOREIGN_DZ_LAYOUT_DZ) {
+    tileLayout(VIPS_FOREIGN_DZ_LAYOUT_DZ),
+    tileFormat("jpeg") {
       background[0] = 0.0;
       background[1] = 0.0;
       background[2] = 0.0;

--- a/test/unit/tile.js
+++ b/test/unit/tile.js
@@ -128,6 +128,22 @@ describe('Tile', function () {
     });
   });
 
+  it('Valid formats pass', function () {
+    ['jpeg', 'png', 'webp'].forEach(function (format) {
+      assert.doesNotThrow(function () {
+        sharp().toFormat(format).tile();
+      });
+    });
+  });
+
+  it('Invalid formats fail', function () {
+    ['zoinks', 1, 'tiff', 'raw'].forEach(function (format) {
+      assert.throws(function () {
+        sharp().toFormat(format).tile();
+      });
+    });
+  });
+
   it('Prevent larger overlap than default size', function () {
     assert.throws(function () {
       sharp().tile({overlap: 257});
@@ -215,6 +231,31 @@ describe('Tile', function () {
           assert.strictEqual(3, info.channels);
           assert.strictEqual('number', typeof info.size);
           fs.stat(path.join(directory, '0', '0', '0.jpg'), function (err, stat) {
+            if (err) throw err;
+            assert.strictEqual(true, stat.isFile());
+            assert.strictEqual(true, stat.size > 0);
+            done();
+          });
+        });
+    });
+  });
+
+  it('Google layout with custom format', function (done) {
+    const directory = fixtures.path('output.png.google.dzi');
+    rimraf(directory, function () {
+      sharp(fixtures.inputJpg)
+        .png()
+        .tile({
+          layout: 'google'
+        })
+        .toFile(directory, function (err, info) {
+          if (err) throw err;
+          assert.strictEqual('dz', info.format);
+          assert.strictEqual(2725, info.width);
+          assert.strictEqual(2225, info.height);
+          assert.strictEqual(3, info.channels);
+          assert.strictEqual('number', typeof info.size);
+          fs.stat(path.join(directory, '0', '0', '0.png'), function (err, stat) {
             if (err) throw err;
             assert.strictEqual(true, stat.isFile());
             assert.strictEqual(true, stat.size > 0);

--- a/test/unit/tile.js
+++ b/test/unit/tile.js
@@ -137,7 +137,7 @@ describe('Tile', function () {
   });
 
   it('Invalid formats fail', function () {
-    ['zoinks', 1, 'tiff', 'raw'].forEach(function (format) {
+    ['tiff', 'raw'].forEach(function (format) {
       assert.throws(function () {
         sharp().toFormat(format).tile();
       });

--- a/test/unit/tile.js
+++ b/test/unit/tile.js
@@ -240,11 +240,11 @@ describe('Tile', function () {
     });
   });
 
-  it('Google layout with custom format', function (done) {
-    const directory = fixtures.path('output.png.google.dzi');
+  it('Google layout with jpeg format', function (done) {
+    const directory = fixtures.path('output.jpg.google.dzi');
     rimraf(directory, function () {
       sharp(fixtures.inputJpg)
-        .png()
+        .jpeg({ quality: 1 })
         .tile({
           layout: 'google'
         })
@@ -255,11 +255,91 @@ describe('Tile', function () {
           assert.strictEqual(2225, info.height);
           assert.strictEqual(3, info.channels);
           assert.strictEqual('number', typeof info.size);
-          fs.stat(path.join(directory, '0', '0', '0.png'), function (err, stat) {
+          const sample = path.join(directory, '0', '0', '0.jpg');
+          sharp(sample).metadata(function (err, metadata) {
             if (err) throw err;
-            assert.strictEqual(true, stat.isFile());
-            assert.strictEqual(true, stat.size > 0);
-            done();
+            assert.strictEqual('jpeg', metadata.format);
+            assert.strictEqual('srgb', metadata.space);
+            assert.strictEqual(3, metadata.channels);
+            assert.strictEqual(false, metadata.hasProfile);
+            assert.strictEqual(false, metadata.hasAlpha);
+            assert.strictEqual(true, metadata.width === 256);
+            assert.strictEqual(true, metadata.height === 256);
+            fs.stat(sample, function (err, stat) {
+              if (err) throw err;
+              assert.strictEqual(true, stat.size < 2000);
+              done();
+            });
+          });
+        });
+    });
+  });
+
+  it('Google layout with png format', function (done) {
+    const directory = fixtures.path('output.png.google.dzi');
+    rimraf(directory, function () {
+      sharp(fixtures.inputJpg)
+        .png({ compressionLevel: 1 })
+        .tile({
+          layout: 'google'
+        })
+        .toFile(directory, function (err, info) {
+          if (err) throw err;
+          assert.strictEqual('dz', info.format);
+          assert.strictEqual(2725, info.width);
+          assert.strictEqual(2225, info.height);
+          assert.strictEqual(3, info.channels);
+          assert.strictEqual('number', typeof info.size);
+          const sample = path.join(directory, '0', '0', '0.png');
+          sharp(sample).metadata(function (err, metadata) {
+            if (err) throw err;
+            assert.strictEqual('png', metadata.format);
+            assert.strictEqual('srgb', metadata.space);
+            assert.strictEqual(3, metadata.channels);
+            assert.strictEqual(false, metadata.hasProfile);
+            assert.strictEqual(false, metadata.hasAlpha);
+            assert.strictEqual(true, metadata.width === 256);
+            assert.strictEqual(true, metadata.height === 256);
+            fs.stat(sample, function (err, stat) {
+              if (err) throw err;
+              assert.strictEqual(true, stat.size > 44000);
+              done();
+            });
+          });
+        });
+    });
+  });
+
+  it('Google layout with webp format', function (done) {
+    const directory = fixtures.path('output.webp.google.dzi');
+    rimraf(directory, function () {
+      sharp(fixtures.inputJpg)
+        .webp({ quality: 1 })
+        .tile({
+          layout: 'google'
+        })
+        .toFile(directory, function (err, info) {
+          if (err) throw err;
+          assert.strictEqual('dz', info.format);
+          assert.strictEqual(2725, info.width);
+          assert.strictEqual(2225, info.height);
+          assert.strictEqual(3, info.channels);
+          assert.strictEqual('number', typeof info.size);
+          const sample = path.join(directory, '0', '0', '0.webp');
+          sharp(sample).metadata(function (err, metadata) {
+            if (err) throw err;
+            assert.strictEqual('webp', metadata.format);
+            assert.strictEqual('srgb', metadata.space);
+            assert.strictEqual(3, metadata.channels);
+            assert.strictEqual(false, metadata.hasProfile);
+            assert.strictEqual(false, metadata.hasAlpha);
+            assert.strictEqual(true, metadata.width === 256);
+            assert.strictEqual(true, metadata.height === 256);
+            fs.stat(sample, function (err, stat) {
+              if (err) throw err;
+              assert.strictEqual(true, stat.size < 2000);
+              done();
+            });
           });
         });
     });


### PR DESCRIPTION
This PR adds format propagation to the tile output, fixing https://github.com/lovell/sharp/issues/337. Specifically, it forwards the output format and output format options through the suffix argument to vips. Format propagation only occurs if explicitly set (i.e. not `input`), otherwise it defaults to the current behavior of `jpeg`.

I've only added support for `jpeg`, `png` and `webp` since those seem like the most desirable tile formats. Also, when using `jpeg` with Google or Zoomify layouts, the `.jpg` extension is used instead of `.jpeg` as per [libvips defaults](https://github.com/jcupitt/libvips/blob/6bff578fd978bace5959e894341809628928c0b5/libvips/foreign/dzsave.c#L1677) and to maintain compatibility.

Usage looks like this:

```js
sharp('huge-map.svg')
  .background('transparent')
  .resize(8162, 8162)
  .webp({ quality: 1 }) // new
  .tile({ layout: 'google' })
  .toFile('./tiles', function (err, info) {
    if (err) throw err;
    // ./tiles/0/0/0.webp contains a very ugly webp encoded tile
  });
```

PR is against master because "ridge" branch does not appear to exist.