### PR TITLE
Better Error Messages for Strings in Resize

### DIFF
--- a/lib/resize.js
+++ b/lib/resize.js
@@ -103,6 +103,8 @@ const resize = function resize (width, height, options) {
   if (is.defined(width)) {
     if (is.integer(width) && is.inRange(width, 1, this.constructor.maximum.width)) {
       this.options.width = width;
+    } else if (is.string(width)) {
+      throw new Error('Invalid width ' + width + '. Cannot be string.');
     } else {
       throw new Error('Invalid width (1 to ' + this.constructor.maximum.width + ') ' + width);
     }
@@ -112,6 +114,8 @@ const resize = function resize (width, height, options) {
   if (is.defined(height)) {
     if (is.integer(height) && is.inRange(height, 1, this.constructor.maximum.height)) {
       this.options.height = height;
+    } else if (is.string(height)) {
+      throw new Error('Invalid height ' + height + '. Cannot be string.');
     } else {
       throw new Error('Invalid height (1 to ' + this.constructor.maximum.height + ') ' + height);
     }


### PR DESCRIPTION
Added Error Message "Invalid width [width].  Cannot be string."
Added Error Message "Invalid height [height].  Cannot be string."

This will make it easier for developers to identify when they have mis-cast their variables before sending them into sharp.resize()