### PR TITLE
Remove parentheses from sharp.format example

### DIFF
--- a/docs/api-constructor.md
+++ b/docs/api-constructor.md
@@ -50,7 +50,7 @@ An Object containing nested boolean values representing the available input and 
 **Examples**
 
 ```javascript
-console.log(sharp.format());
+console.log(sharp.format);
 ```
 
 Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 


### PR DESCRIPTION
With parentheses it gets "sharp.format is not a function"