### PR TITLE
Add CLI tools section to installation guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -135,6 +135,11 @@ You can now download your deployment ZIP using `scp` and upload it to Lambda. Be
 * [gulp-responsive](https://www.npmjs.com/package/gulp-responsive)
 * [grunt-sharp](https://www.npmjs.com/package/grunt-sharp)
 
+
+### CLI tools
+
+* [sharp-cli](https://www.npmjs.com/package/sharp-cli)
+
 ### Security
 
 Many users of this module process untrusted, user-supplied images,


### PR DESCRIPTION
As recommended in #81, add a CLI tools section to the installation guide.