### PR TITLE
add Debian jessie based dockerfiles links to the documentation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -105,6 +105,13 @@ docker pull marcbachmann/libvips
 docker pull wjordan/libvips
 ```
 
+[Tailor Brands](https://github.com/TailorBrands) maintain
+[Debian-based Dockerfiles for libvips and nodejs](https://github.com/TailorBrands/docker-libvips).
+
+```sh
+docker pull tailor/docker-libvips
+```
+
 ### AWS Lambda
 
 In order to use sharp on AWS Lambda, you need to [create a deployment package](http://docs.aws.amazon.com/lambda/latest/dg/nodejs-create-deployment-pkg.html). Because sharp

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "Rahul Nanwani <r.nanwani@gmail.com>",
     "Alice Monday <alice0meta@gmail.com>",
     "Kristo Jorgenson <kristo.jorgenson@gmail.com>",
-    "YvesBos <yves_bos@outlook.com>"
+    "YvesBos <yves_bos@outlook.com>",
+    "Guy Maliar <guy@tailorbrands.com>"
   ],
   "scripts": {
     "clean": "rm -rf node_modules/ build/ vendor/ coverage/ test/fixtures/output.*",


### PR DESCRIPTION
Hey guys, we've created over at TailorBrands a few docker files based on Debian Jessie for libvips 8.4.6 and 8.5.5 and also pre-baked node.js images as well,
We're happy to share them and maintain them as we use Sharp ourselves!