### PR TITLE
Add SHARP_DIST_AUTH_HEADER to pass basic authorization for libvips download

### DIFF
--- a/binding.js
+++ b/binding.js
@@ -19,6 +19,8 @@ const platform = process.env.npm_config_platform || process.platform;
 
 const arch = process.env.npm_config_arch || process.arch;
 
+const distAuthHeader = process.env.SHARP_DIST_AUTH_HEADER;
+
 // -- Helpers
 
 // Does this file exist?
@@ -100,6 +102,9 @@ module.exports.download_vips = function () {
           protocol: 'https'
         })
       };
+      if (distAuthHeader) {
+        gotOpt.auth = distAuthHeader;
+      }
       const url = distBaseUrl + tarFilename;
       got.stream(url, gotOpt).on('response', function (response) {
         if (response.statusCode !== 200) {

--- a/docs/install.md
+++ b/docs/install.md
@@ -215,6 +215,13 @@ SHARP_DIST_BASE_URL="https://hostname/path/" npm install sharp
 
 to use `https://hostname/path/libvips-x.y.z-platform.tar.gz`.
 
+Should you need to download from a URL that requires basic authentication,
+set the `SHARP_DIST_AUTH_HEADER` environment variable, e.g.
+
+```sh
+SHARP_DIST_AUTH_HEADER="username:password" SHARP_DIST_BASE_URL="https://hostname/path/" npm install sharp
+```
+
 ### Licences
 
 This module is licensed under the terms of the

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "Kristo Jorgenson <kristo.jorgenson@gmail.com>",
     "YvesBos <yves_bos@outlook.com>",
     "Guy Maliar <guy@tailorbrands.com>",
-    "Nicolas Coden <nicolas@ncoden.fr>"
+    "Nicolas Coden <nicolas@ncoden.fr>",
+    "Matt Parrish <matt.r.parrish@gmail.com>"
   ],
   "scripts": {
     "clean": "rm -rf node_modules/ build/ vendor/ coverage/ test/fixtures/output.*",


### PR DESCRIPTION
Fixes #938

Setting `SHARP_DIST_BASE_URL="https://username:password@hostname/path/"` doesn't work as the `got` library throws the error: `Error: Basic authentication must be done with auth option`. This pull request allows the user to specify `SHARP_DIST_AUTH_HEADER="username:password"` which will set the auth header on the `got` request for libvips.