### PR TITLE
Facilitate bundling of sharp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,13 @@
 'use strict';
 
 const Sharp = require('./constructor');
-[
-  'input',
-  'resize',
-  'composite',
-  'operation',
-  'colour',
-  'channel',
-  'output',
-  'utility'
-].forEach(function (decorator) {
-  require('./' + decorator)(Sharp);
-});
+require('./input')(Sharp);
+require('./resize')(Sharp);
+require('./composite')(Sharp);
+require('./operation')(Sharp);
+require('./colour')(Sharp);
+require('./channel')(Sharp);
+require('./output')(Sharp);
+require('./utility')(Sharp);
 
 module.exports = Sharp;


### PR DESCRIPTION
Dynamic require statements make it more difficult for a bundler to figure out the needed modules. In this case there's not much benefit in code reduction either, so just revert to static strings inside the require statement.

This (together with providing a list of dlls to include) makes it possible to bundle a nodejs application using sharp into a stand-alone executable using nexe.