### PR TITLE
Changes documentation for withoutEnlargement to false

### DIFF
--- a/docs/api-resize.md
+++ b/docs/api-resize.md
@@ -172,6 +172,6 @@ This is equivalent to GraphicsMagick's `>` geometry option:
 
 **Parameters**
 
--   `withoutEnlargement` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**  (optional, default `true`)
+-   `withoutEnlargement` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**  (optional, default `false`)
 
 Returns **Sharp** 


### PR DESCRIPTION
Fixes the issue docs:withoutEnlargement is false by default #972
