### PR TITLE
Adding mention of max() to preserve ratio in withoutEnlargement

### DIFF
--- a/docs/api-resize.md
+++ b/docs/api-resize.md
@@ -162,7 +162,7 @@ Returns **Sharp**
 
 Do not enlarge the output image if the input image width _or_ height are already less than the required dimensions.
 This is equivalent to GraphicsMagick's `>` geometry option:
-"_change the dimensions of the image only if its width or height exceeds the geometry specification_". Use with `max()` to preserve the image's aspect ratio.
+"_change the dimensions of the image only if its width or height exceeds the geometry specification_".
 
 The default behaviour _before_ function call is `false`, meaning the image will be enlarged.
 

--- a/docs/api-resize.md
+++ b/docs/api-resize.md
@@ -162,7 +162,7 @@ Returns **Sharp**
 
 Do not enlarge the output image if the input image width _or_ height are already less than the required dimensions.
 This is equivalent to GraphicsMagick's `>` geometry option:
-"_change the dimensions of the image only if its width or height exceeds the geometry specification_".
+"_change the dimensions of the image only if its width or height exceeds the geometry specification_". Use with `max()` to preserve the image's aspect ratio.
 
 The default behaviour _before_ function call is `false`, meaning the image will be enlarged.
 

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -253,6 +253,7 @@ function ignoreAspectRatio () {
  * Do not enlarge the output image if the input image width *or* height are already less than the required dimensions.
  * This is equivalent to GraphicsMagick's `>` geometry option:
  * "*change the dimensions of the image only if its width or height exceeds the geometry specification*".
+ * Use with `max()` to preserve the image's aspect ratio.
  *
  * The default behaviour *before* function call is `false`, meaning the image will be enlarged.
  *


### PR DESCRIPTION
The `withoutEnlargement()` and `max()` methods are the ones that, together, will match ImageMagick's behaviour. I added a mention to `max()`, which I would have found helpful.
