### PR TITLE
Add Group 4 (CCITTFAX4) compression to TIFF output

### DIFF
--- a/docs/api-output.md
+++ b/docs/api-output.md
@@ -213,7 +213,7 @@ Use these TIFF options for output image.
 -   `options` **[Object][15]?** output options
     -   `options.quality` **[Number][18]** quality, integer 1-100 (optional, default `80`)
     -   `options.force` **[Boolean][16]** force TIFF output, otherwise attempt to use input format (optional, default `true`)
-    -   `options.compression` **[Boolean][16]** compression options: lzw, deflate, jpeg (optional, default `'jpeg'`)
+    -   `options.compression` **[Boolean][16]** compression options: lzw, deflate, jpeg, ccittfax4 (optional, default `'jpeg'`)
     -   `options.predictor` **[Boolean][16]** compression predictor options: none, horizontal, float (optional, default `'horizontal'`)
     -   `options.xres` **[Number][18]** horizontal resolution in pixels/mm (optional, default `1.0`)
     -   `options.yres` **[Number][18]** vertical resolution in pixels/mm (optional, default `1.0`)

--- a/lib/output.js
+++ b/lib/output.js
@@ -326,10 +326,10 @@ function tiff (options) {
   }
   // compression
   if (is.defined(options) && is.defined(options.compression)) {
-    if (is.string(options.compression) && is.inArray(options.compression, ['lzw', 'deflate', 'jpeg', 'none'])) {
+    if (is.string(options.compression) && is.inArray(options.compression, ['lzw', 'deflate', 'jpeg', 'ccittfax4', 'none'])) {
       this.options.tiffCompression = options.compression;
     } else {
-      const message = `Invalid compression option "${options.compression}". Should be one of: lzw, deflate, jpeg, none`;
+      const message = `Invalid compression option "${options.compression}". Should be one of: lzw, deflate, jpeg, ccittfax4, none`;
       throw new Error(message);
     }
   }

--- a/test/unit/io.js
+++ b/test/unit/io.js
@@ -1083,6 +1083,22 @@ describe('Input/output', function () {
       });
   });
 
+  it('TIFF ccittfax4 compression shrinks b-w test file', function (done) {
+    const startSize = fs.statSync(fixtures.inputTiff).size;
+    sharp(fixtures.inputTiff)
+      .toColourspace('b-w')
+      .tiff({
+        squash: true,
+        compression: 'ccittfax4'
+      })
+      .toFile(fixtures.outputTiff, (err, info) => {
+        if (err) throw err;
+        assert.strictEqual('tiff', info.format);
+        assert(info.size < startSize);
+        fs.unlink(fixtures.outputTiff, done);
+      });
+  });
+
   it('TIFF deflate compression with horizontal predictor shrinks test file', function (done) {
     const startSize = fs.statSync(fixtures.inputTiffUncompressed).size;
     sharp(fixtures.inputTiffUncompressed)


### PR DESCRIPTION
This PR addresses #1207, with one concern mentioned below. Any insight/feedback is appreciated.

It isn't clear to me why the test case required `.toColourspace('b-w')` to compress properly. If we check the input document's metadata, the space is already 'b-w'.

Output of fixtures.inputTiff metadata:
```js
{
  format: 'tiff',
  width: 2464,
  height: 3248,
  space: 'b-w',
  channels: 1,
  depth: 'uchar',
  density: 300,
  hasProfile: false,
  hasAlpha: false,
  orientation: 1
}
```