### PR TITLE
docs: fix webp alphaQuality range

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -261,10 +261,10 @@ function webp (options) {
     }
   }
   if (is.object(options) && is.defined(options.alphaQuality)) {
-    if (is.integer(options.alphaQuality) && is.inRange(options.alphaQuality, 1, 100)) {
+    if (is.integer(options.alphaQuality) && is.inRange(options.alphaQuality, 0, 100)) {
       this.options.webpAlphaQuality = options.alphaQuality;
     } else {
-      throw new Error('Invalid webp alpha quality (integer, 1-100) ' + options.alphaQuality);
+      throw new Error('Invalid webp alpha quality (integer, 0-100) ' + options.alphaQuality);
     }
   }
   if (is.object(options) && is.defined(options.lossless)) {


### PR DESCRIPTION
As specified [in code](https://github.com/lovell/sharp/blob/master/lib/output.js#L267) webp alphaQuality range is 1-100, not 0-100