### PR TITLE
Updated the "make a transparent image" example

### DIFF
--- a/docs/api-constructor.md
+++ b/docs/api-constructor.md
@@ -55,7 +55,7 @@ sharp({
     width: 300,
     height: 200,
     channels: 4,
-    background: { r: 255, g: 0, b: 0, alpha: 128 }
+    background: { r: 255, g: 0, b: 0, alpha: 0.5 }
   }
 })
 .png()

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -81,7 +81,7 @@ const debuglog = util.debuglog('sharp');
  *     width: 300,
  *     height: 200,
  *     channels: 4,
- *     background: { r: 255, g: 0, b: 0, alpha: 128 }
+ *     background: { r: 255, g: 0, b: 0, alpha: 0.5 }
  *   }
  * })
  * .png()


### PR DESCRIPTION
Alpha for the JS color module is between 0-1, not 0-255.