### PR TITLE
Pass tile depth parameter down to libvips

### DIFF
--- a/docs/api-output.md
+++ b/docs/api-output.md
@@ -279,8 +279,9 @@ Warning: multiple sharp instances concurrently producing tile output can expose 
     -   `tile.overlap` **[Number][8]** tile overlap in pixels, a value between 0 and 8192. (optional, default `0`)
     -   `tile.angle` **[Number][8]** tile angle of rotation, must be a multiple of 90. (optional, default `0`)
     -   `tile.container` **[String][1]** tile container, with value `fs` (filesystem) or `zip` (compressed file). (optional, default `'fs'`)
-    -   `tile.layout` **[String][1]** filesystem layout, possible values are `dz`, `zoomify` or `google`. (optional, default `'dz'`)
-
+    -   `tile.layout` **[String][1]** filesystem layout, possible values are `dz`, `zoomify` or `google`. (optional, default `'dz'`) 
+    -   `tile.depth` **[String][1]** pyramid depth, possible values are `onepixel`, `onetile` or `one`. (optional, default - libvips selects one based on layout) 
+    
 ### Examples
 
 ```javascript

--- a/lib/output.js
+++ b/lib/output.js
@@ -423,6 +423,7 @@ function toFormat (format, options) {
  * @param {Number} [tile.size=256] tile size in pixels, a value between 1 and 8192.
  * @param {Number} [tile.overlap=0] tile overlap in pixels, a value between 0 and 8192.
  * @param {Number} [tile.angle=0] tile angle of rotation, must be a multiple of 90.
+ * @param {String} [tile.depth] depth to shrink tiles, with value 'onepixel', 'onetile' or 'one', default based on layout
  * @param {String} [tile.container='fs'] tile container, with value `fs` (filesystem) or `zip` (compressed file).
  * @param {String} [tile.layout='dz'] filesystem layout, possible values are `dz`, `zoomify` or `google`.
  * @returns {Sharp}
@@ -472,6 +473,15 @@ function tile (tile) {
         this.options.tileAngle = tile.angle;
       } else {
         throw new Error('Unsupported angle: angle must be a positive/negative multiple of 90 ' + tile.angle);
+      }
+    }
+
+    // Depth of tiles
+    if (is.defined(tile.depth)) {
+      if (is.string(tile.depth) && is.inArray(tile.depth, ['onepixel', 'onetile', 'one'])) {
+        this.options.tileDepth = tile.depth;
+      } else {
+        throw new Error("Invalid tile depth '" + tile.depth + "', should be one of 'onepixel', 'onetile' or 'one'");
       }
     }
   }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -139,6 +139,7 @@ struct PipelineBaton {
   VipsForeignDzLayout tileLayout;
   std::string tileFormat;
   int tileAngle;
+  VipsForeignDzDepth tileDepth;
 
   PipelineBaton():
     input(nullptr),
@@ -220,7 +221,8 @@ struct PipelineBaton {
     tileOverlap(0),
     tileContainer(VIPS_FOREIGN_DZ_CONTAINER_FS),
     tileLayout(VIPS_FOREIGN_DZ_LAYOUT_DZ),
-    tileAngle(0){
+    tileAngle(0),
+    tileDepth(VIPS_FOREIGN_DZ_DEPTH_LAST){
       background[0] = 0.0;
       background[1] = 0.0;
       background[2] = 0.0;


### PR DESCRIPTION
Hi Lovell,

Stumbled across this issue while using sharp https://github.com/lovell/sharp/issues/1281 and thought I'd have a bash at it...

I don't see 'teeth' in the list of branches as a target for this pull request, am I missing something or am I right to use master (it should be non-breaking but it is a change/addition to the api)

Since libvips chooses a default depth based on the layout detected, I thought it best that sharp didn't choose one itself and instead not provide anything unless explicitly set in the javascript.

Alun.