### PR TITLE
refactor: Move background extraction into separate method.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -255,6 +255,11 @@ namespace sharp {
   */
   std::vector<double> GetRgbaAsColourspace(std::vector<double> const rgba, VipsInterpretation const interpretation);
 
+  /*
+    Apply the alpha channel to a given colour
+   */
+  std::tuple<VImage, std::vector<double>> ApplyAlpha(VImage image, double colour[4]);
+
 }  // namespace sharp
 
 #endif  // SRC_COMMON_H_


### PR DESCRIPTION
While working on the rotation feature I came across a 25-line segment that was duplicated and that I probably will need to duplicate again, so I thought I might as well move it into a reusable function.

It's neither a bugfix nor a new feature, so tests stay the same.

If you prefer me including this in the rotation PR, let me know, but I thought it was more proper to do it separately.