### PR TITLE
Update Alpine libvips installation instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -72,7 +72,9 @@ libvips is available in the
 [testing repository](https://pkgs.alpinelinux.org/packages?name=vips-dev):
 
 ```sh
-apk add vips-dev fftw-dev build-base --update-cache --repository https://dl-3.alpinelinux.org/alpine/edge/testing/
+apk add vips-dev fftw-dev build-base --update-cache \
+    --repository https://dl-3.alpinelinux.org/alpine/edge/testing/ \
+    --repository https://dl-3.alpinelinux.org/alpine/edge/main
 ```
 
 The smaller stack size of musl libc means


### PR DESCRIPTION
With version 8.7.0 of the vips-dev Alpine package the documented installation instructions no longer work and result in:

ERROR: unsatisfiable constraints:
  pc:fftw3 (missing):
    required by: vips-dev-8.7.0-r0[pc:fftw3] vips-dev-8.7.0-r0[pc:fftw3] vips-dev-8.7.0-r0[pc:fftw3]

The fix was proposed in https://bugs.alpinelinux.org/issues/9561#note-2