### PR TITLE
Add mitchell kernel

### DIFF
--- a/docs/api-resize.md
+++ b/docs/api-resize.md
@@ -30,6 +30,7 @@ Possible interpolation kernels are:
 
 -   `nearest`: Use [nearest neighbour interpolation][4].
 -   `cubic`: Use a [Catmull-Rom spline][5].
+-   `mitchell`: Use a [Mitchell-Netravali spline][13].
 -   `lanczos2`: Use a [Lanczos kernel][6] with `a=2`.
 -   `lanczos3`: Use a Lanczos kernel with `a=3` (the default).
 
@@ -230,3 +231,5 @@ Returns **Sharp**
 [11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
 [12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error
+
+[13]: https://www.cs.utexas.edu/~fussell/courses/cs384g-fall2013/lectures/mitchell/Mitchell.pdf

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,10 @@ Requires libvips v8.7.0.
   [#1422](https://github.com/lovell/sharp/pull/1422)
   [@SethWen](https://github.com/SethWen)
 
+* Add support for the "mitchell" kernel for image reductions.
+  [#1438](https://github.com/lovell/sharp/pull/1438)
+  [@Daiz](https://github.com/Daiz)
+
 #### v0.21.0 - 4<sup>th</sup> October 2018
 
 * Deprecate the following resize-related functions:

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -55,6 +55,7 @@ const strategy = {
 const kernel = {
   nearest: 'nearest',
   cubic: 'cubic',
+  mitchell: 'mitchell',
   lanczos2: 'lanczos2',
   lanczos3: 'lanczos3'
 };
@@ -110,6 +111,7 @@ const mapFitToCanvas = {
  * Possible interpolation kernels are:
  * - `nearest`: Use [nearest neighbour interpolation](http://en.wikipedia.org/wiki/Nearest-neighbor_interpolation).
  * - `cubic`: Use a [Catmull-Rom spline](https://en.wikipedia.org/wiki/Centripetal_Catmull%E2%80%93Rom_spline).
+ * - `mitchell`: Use a [Mitchell-Netravali spline](https://www.cs.utexas.edu/~fussell/courses/cs384g-fall2013/lectures/mitchell/Mitchell.pdf).
  * - `lanczos2`: Use a [Lanczos kernel](https://en.wikipedia.org/wiki/Lanczos_resampling#Lanczos_kernel) with `a=2`.
  * - `lanczos3`: Use a Lanczos kernel with `a=3` (the default).
  *

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "Alun Davies <alun.owain.davies@googlemail.com>",
     "Aidan Hoolachan <ajhoolachan21@gmail.com>",
     "Axel Eirola <axel.eirola@iki.fi>",
-    "Freezy <freezy@xbmc.org>"
+    "Freezy <freezy@xbmc.org>",
+    "Daiz <taneli.vatanen@gmail.com>"
   ],
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node-gyp rebuild && node install/dll-copy)",

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -381,7 +381,7 @@ class PipelineWorker : public Nan::AsyncWorker {
           vips_enum_from_nick(nullptr, VIPS_TYPE_KERNEL, baton->kernel.data()));
         if (
           kernel != VIPS_KERNEL_NEAREST && kernel != VIPS_KERNEL_CUBIC && kernel != VIPS_KERNEL_LANCZOS2 &&
-          kernel != VIPS_KERNEL_LANCZOS3
+          kernel != VIPS_KERNEL_LANCZOS3 && kernel != VIPS_KERNEL_MITCHELL
         ) {
           throw vips::VError("Unknown kernel");
         }

--- a/test/unit/resize.js
+++ b/test/unit/resize.js
@@ -497,6 +497,7 @@ describe('Resize dimensions', function () {
   [
     sharp.kernel.nearest,
     sharp.kernel.cubic,
+    sharp.kernel.mitchell,
     sharp.kernel.lanczos2,
     sharp.kernel.lanczos3
   ].forEach(function (kernel) {


### PR DESCRIPTION
Pull request for #1432. Adds newly available (as of libvips 8.7.0) Mitchell-Netravali spline as a resize kernel option.