### PR TITLE
Do not rely on function names to populate Sharp's prototype so that the library can be minified. Fixes #1474.

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -117,14 +117,12 @@ function bandbool (boolOp) {
  * @private
  */
 module.exports = function (Sharp) {
-  // Public instance functions
-  [
+  Object.assign(Sharp.prototype, {
+    // Public instance functions
     removeAlpha,
     extractChannel,
     joinChannel,
     bandbool
-  ].forEach(function (f) {
-    Sharp.prototype[f.name] = f;
   });
   // Class attributes
   Sharp.bool = bool;

--- a/lib/colour.js
+++ b/lib/colour.js
@@ -123,7 +123,7 @@ function _setColourOption (key, val) {
  * @private
  */
 module.exports = function (Sharp) {
-  [
+  Object.assign(Sharp.prototype, {
     // Public
     tint,
     greyscale,
@@ -132,8 +132,6 @@ module.exports = function (Sharp) {
     toColorspace,
     // Private
     _setColourOption
-  ].forEach(function (f) {
-    Sharp.prototype[f.name] = f;
   });
   // Class attributes
   Sharp.colourspace = colourspace;

--- a/lib/input.js
+++ b/lib/input.js
@@ -362,7 +362,7 @@ function sequentialRead (sequentialRead) {
  * @private
  */
 module.exports = function (Sharp) {
-  [
+  Object.assign(Sharp.prototype, {
     // Private
     _createInputDescriptor,
     _write,
@@ -374,7 +374,5 @@ module.exports = function (Sharp) {
     stats,
     limitInputPixels,
     sequentialRead
-  ].forEach(function (f) {
-    Sharp.prototype[f.name] = f;
   });
 };

--- a/lib/operation.js
+++ b/lib/operation.js
@@ -383,7 +383,7 @@ function linear (a, b) {
  * @private
  */
 module.exports = function (Sharp) {
-  [
+  Object.assign(Sharp.prototype, {
     rotate,
     flip,
     flop,
@@ -399,7 +399,5 @@ module.exports = function (Sharp) {
     threshold,
     boolean,
     linear
-  ].forEach(function (f) {
-    Sharp.prototype[f.name] = f;
   });
 };

--- a/lib/output.js
+++ b/lib/output.js
@@ -641,7 +641,7 @@ function _pipeline (callback) {
  * @private
  */
 module.exports = function (Sharp) {
-  [
+  Object.assign(Sharp.prototype, {
     // Public
     toFile,
     toBuffer,
@@ -658,7 +658,5 @@ module.exports = function (Sharp) {
     _setBooleanOption,
     _read,
     _pipeline
-  ].forEach(function (f) {
-    Sharp.prototype[f.name] = f;
   });
 };

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -469,13 +469,11 @@ function withoutEnlargement (withoutEnlargement) {
  * @private
  */
 module.exports = function (Sharp) {
-  [
+  Object.assign(Sharp.prototype, {
     resize,
     extend,
     extract,
     trim
-  ].forEach(function (f) {
-    Sharp.prototype[f.name] = f;
   });
   // Class attributes
   Sharp.gravity = gravity;


### PR DESCRIPTION
That should solve the issue. All unit tests are passing on my machine. I wasn't able to control if there were no other issues in the code regarding minification compatibility since `msbuild` is being particularly difficult when I reference `sharp` as a `file:` dependency.