### PR TITLE
Add missing comma to `extend` example

### DIFF
--- a/docs/api-resize.md
+++ b/docs/api-resize.md
@@ -143,7 +143,7 @@ sharp(input)
     top: 10,
     bottom: 20,
     left: 10,
-    right: 10
+    right: 10,
     background: { r: 0, g: 0, b: 0, alpha: 0 }
   })
   ...

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -275,7 +275,7 @@ function resize (width, height, options) {
  *     top: 10,
  *     bottom: 20,
  *     left: 10,
- *     right: 10
+ *     right: 10,
  *     background: { r: 0, g: 0, b: 0, alpha: 0 }
  *   })
  *   ...


### PR DESCRIPTION
Came across this while copy-pasting the extend example.