### PR TITLE
Change docs for `composite` to reflect how `create` works

### DIFF
--- a/docs/api-composite.md
+++ b/docs/api-composite.md
@@ -25,11 +25,12 @@ and [https://www.cairographics.org/operators/][2]
             -   `images[].input.create.width` **[Number][7]?** 
             -   `images[].input.create.height` **[Number][7]?** 
             -   `images[].input.create.channels` **[Number][7]?** 3-4
+            -   `images[].input.create.background` **([String][6] \| [Object][4])?** parsed by the [color][8] module to extract values for red, green, blue and alpha.
     -   `images[].blend` **[String][6]** how to blend this image with the image below. (optional, default `'over'`)
     -   `images[].gravity` **[String][6]** gravity at which to place the overlay. (optional, default `'centre'`)
     -   `images[].top` **[Number][7]?** the pixel offset from the top edge.
     -   `images[].left` **[Number][7]?** the pixel offset from the left edge.
-    -   `images[].tile` **[Boolean][8]** set to true to repeat the overlay image across the entire image with the given `gravity`. (optional, default `false`)
+    -   `images[].tile` **[Boolean][9]** set to true to repeat the overlay image across the entire image with the given `gravity`. (optional, default `false`)
     -   `images[].density` **[Number][7]** number representing the DPI for vector overlay image. (optional, default `72`)
     -   `images[].raw` **[Object][4]?** describes overlay when using raw pixel data.
         -   `images[].raw.width` **[Number][7]?** 
@@ -55,7 +56,7 @@ sharp('input.png')
   });
 ```
 
--   Throws **[Error][9]** Invalid parameters
+-   Throws **[Error][10]** Invalid parameters
 
 Returns **Sharp** 
 
@@ -73,6 +74,8 @@ Returns **Sharp**
 
 [7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[8]: https://www.npmjs.org/package/color
 
-[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error
+[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+
+[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error

--- a/docs/api-composite.md
+++ b/docs/api-composite.md
@@ -20,7 +20,11 @@ and [https://www.cairographics.org/operators/][2]
 ### Parameters
 
 -   `images` **[Array][3]&lt;[Object][4]>** Ordered list of images to composite
-    -   `images[].input` **([Buffer][5] \| [String][6])?** Buffer containing image data or String containing the path to an image file.
+    -   `images[].input` **([Buffer][5] \| [String][6])?** Buffer containing image data, String containing the path to an image file, or Crate object (see bellow)
+        -   `images[].input.create` **[Object][4]?** describes a blank overlay to be created.
+            -   `images[].input.create.width` **[Number][7]?** 
+            -   `images[].input.create.height` **[Number][7]?** 
+            -   `images[].input.create.channels` **[Number][7]?** 3-4
     -   `images[].blend` **[String][6]** how to blend this image with the image below. (optional, default `'over'`)
     -   `images[].gravity` **[String][6]** gravity at which to place the overlay. (optional, default `'centre'`)
     -   `images[].top` **[Number][7]?** the pixel offset from the top edge.
@@ -31,11 +35,6 @@ and [https://www.cairographics.org/operators/][2]
         -   `images[].raw.width` **[Number][7]?** 
         -   `images[].raw.height` **[Number][7]?** 
         -   `images[].raw.channels` **[Number][7]?** 
-    -   `images[].create` **[Object][4]?** describes a blank overlay to be created.
-        -   `images[].create.width` **[Number][7]?** 
-        -   `images[].create.height` **[Number][7]?** 
-        -   `images[].create.channels` **[Number][7]?** 3-4
-        -   `images[].create.background` **([String][6] \| [Object][4])?** parsed by the [color][9] module to extract values for red, green, blue and alpha.
 
 ### Examples
 
@@ -56,7 +55,7 @@ sharp('input.png')
   });
 ```
 
--   Throws **[Error][10]** Invalid parameters
+-   Throws **[Error][9]** Invalid parameters
 
 Returns **Sharp** 
 
@@ -76,6 +75,4 @@ Returns **Sharp**
 
 [8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[9]: https://www.npmjs.org/package/color
-
-[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error
+[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error

--- a/docs/api-composite.md
+++ b/docs/api-composite.md
@@ -20,7 +20,7 @@ and [https://www.cairographics.org/operators/][2]
 ### Parameters
 
 -   `images` **[Array][3]&lt;[Object][4]>** Ordered list of images to composite
-    -   `images[].input` **([Buffer][5] \| [String][6])?** Buffer containing image data, String containing the path to an image file, or Crate object (see bellow)
+    -   `images[].input` **([Buffer][5] \| [String][6])?** Buffer containing image data, String containing the path to an image file, or Create object (see bellow)
         -   `images[].input.create` **[Object][4]?** describes a blank overlay to be created.
             -   `images[].input.create.width` **[Number][7]?** 
             -   `images[].input.create.height` **[Number][7]?** 

--- a/lib/composite.js
+++ b/lib/composite.js
@@ -72,7 +72,7 @@ const blend = {
  *   });
  *
  * @param {Object[]} images - Ordered list of images to composite
- * @param {Buffer|String} [images[].input] - Buffer containing image data, String containing the path to an image file, or Crate object (see bellow)
+ * @param {Buffer|String} [images[].input] - Buffer containing image data, String containing the path to an image file, or Create object (see bellow)
  * @param {Object} [images[].input.create] - describes a blank overlay to be created.
  * @param {Number} [images[].input.create.width]
  * @param {Number} [images[].input.create.height]

--- a/lib/composite.js
+++ b/lib/composite.js
@@ -72,7 +72,11 @@ const blend = {
  *   });
  *
  * @param {Object[]} images - Ordered list of images to composite
- * @param {Buffer|String} [images[].input] - Buffer containing image data or String containing the path to an image file.
+ * @param {Buffer|String} [images[].input] - Buffer containing image data, String containing the path to an image file, or Crate object (see bellow)
+ * @param {Object} [images[].input.create] - describes a blank overlay to be created.
+ * @param {Number} [images[].input.create.width]
+ * @param {Number} [images[].input.create.height]
+ * @param {Number} [images[].input.create.channels] - 3-4
  * @param {String} [images[].blend='over'] - how to blend this image with the image below.
  * @param {String} [images[].gravity='centre'] - gravity at which to place the overlay.
  * @param {Number} [images[].top] - the pixel offset from the top edge.
@@ -83,10 +87,6 @@ const blend = {
  * @param {Number} [images[].raw.width]
  * @param {Number} [images[].raw.height]
  * @param {Number} [images[].raw.channels]
- * @param {Object} [images[].create] - describes a blank overlay to be created.
- * @param {Number} [images[].create.width]
- * @param {Number} [images[].create.height]
- * @param {Number} [images[].create.channels] - 3-4
  * @param {String|Object} [images[].create.background] - parsed by the [color](https://www.npmjs.org/package/color) module to extract values for red, green, blue and alpha.
  * @returns {Sharp}
  * @throws {Error} Invalid parameters

--- a/lib/composite.js
+++ b/lib/composite.js
@@ -77,6 +77,7 @@ const blend = {
  * @param {Number} [images[].input.create.width]
  * @param {Number} [images[].input.create.height]
  * @param {Number} [images[].input.create.channels] - 3-4
+ * @param {String|Object} [images[].input.create.background] - parsed by the [color](https://www.npmjs.org/package/color) module to extract values for red, green, blue and alpha.
  * @param {String} [images[].blend='over'] - how to blend this image with the image below.
  * @param {String} [images[].gravity='centre'] - gravity at which to place the overlay.
  * @param {Number} [images[].top] - the pixel offset from the top edge.
@@ -87,7 +88,6 @@ const blend = {
  * @param {Number} [images[].raw.width]
  * @param {Number} [images[].raw.height]
  * @param {Number} [images[].raw.channels]
- * @param {String|Object} [images[].create.background] - parsed by the [color](https://www.npmjs.org/package/color) module to extract values for red, green, blue and alpha.
  * @returns {Sharp}
  * @throws {Error} Invalid parameters
  */


### PR DESCRIPTION
I found an error in docs for `composite` method. The `create` object should be documented under `images[].input` not inside `images[]`. No changes to the code itself.