### PR TITLE
Add warning if sharp bindings aren't built correctly

### DIFF
--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -7,7 +7,26 @@ const events = require('events');
 const is = require('./is');
 
 require('./libvips').hasVendoredLibvips();
-const sharp = require('bindings')('sharp.node');
+
+let sharp;
+
+try {
+  sharp = require('bindings')('sharp.node');
+} catch (error) {
+  // Bail early if bindings aren't available
+  console.error(
+    `
+      "sharp" does not seem to have been built or installed correctly.
+
+      - Try to reinstall packages and look for errors during installation
+      - Consult "sharp" installation page at http://sharp.pixelplumbing.com/en/stable/install/
+
+      If neither of the above work, please open an issue in https://github.com/lovell/sharp/issues
+    `
+  );
+  throw error;
+}
+
 
 // Use NODE_DEBUG=sharp to enable libvips warnings
 const debuglog = util.debuglog('sharp');

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -27,7 +27,6 @@ try {
   throw error;
 }
 
-
 // Use NODE_DEBUG=sharp to enable libvips warnings
 const debuglog = util.debuglog('sharp');
 


### PR DESCRIPTION
Added a friendly error message in case the require to the bindings throws for any reason. The error message looks like this:

```
"sharp" does not seem to have been built or installed correctly.

- Try to reinstall packages and look for errors during installation
- Consult "sharp" installation page at http://sharp.pixelplumbing.com/en/stable/install/

If neither of the above work, please open an issue in https://github.com/lovell/sharp/issues
```

Fixes https://github.com/lovell/sharp/issues/1624