### PR TITLE
add skipBlanks support for dz and zoomify layout

### DIFF
--- a/docs/api-output.md
+++ b/docs/api-output.md
@@ -311,6 +311,7 @@ Warning: multiple sharp instances concurrently producing tile output can expose 
     -   `tile.overlap` **[Number][8]** tile overlap in pixels, a value between 0 and 8192. (optional, default `0`)
     -   `tile.angle` **[Number][8]** tile angle of rotation, must be a multiple of 90. (optional, default `0`)
     -   `tile.depth` **[String][1]?** how deep to make the pyramid, possible values are `onepixel`, `onetile` or `one`, default based on layout.
+    -   `tile.skipBlanks` **[Number][8]** threshold to skip tile generation, a value 0 - 255 for 8-bit images or 0 - 65535 for 16-bit images (optional, default `-1`)
     -   `tile.container` **[String][1]** tile container, with value `fs` (filesystem) or `zip` (compressed file). (optional, default `'fs'`)
     -   `tile.layout` **[String][1]** filesystem layout, possible values are `dz`, `zoomify` or `google`. (optional, default `'dz'`)
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -539,6 +539,7 @@ function toFormat (format, options) {
  * @param {Number} [tile.overlap=0] tile overlap in pixels, a value between 0 and 8192.
  * @param {Number} [tile.angle=0] tile angle of rotation, must be a multiple of 90.
  * @param {String} [tile.depth] how deep to make the pyramid, possible values are `onepixel`, `onetile` or `one`, default based on layout.
+ * @param {Number} [tile.skipBlanks=-1] threshold to skip tile generation, a value 0 - 255 for 8-bit images or 0 - 65535 for 16-bit images
  * @param {String} [tile.container='fs'] tile container, with value `fs` (filesystem) or `zip` (compressed file).
  * @param {String} [tile.layout='dz'] filesystem layout, possible values are `dz`, `zoomify` or `google`.
  * @returns {Sharp}
@@ -597,6 +598,21 @@ function tile (tile) {
         this.options.tileDepth = tile.depth;
       } else {
         throw new Error("Invalid tile depth '" + tile.depth + "', should be one of 'onepixel', 'onetile' or 'one'");
+      }
+    }
+
+    // Threshold of skipping blanks,
+    if (is.defined(tile.skipBlanks)) {
+      if (is.integer(tile.skipBlanks) && is.inRange(tile.skipBlanks, -1, 65535)) {
+        this.options.skipBlanks = tile.skipBlanks;
+      } else {
+        throw new Error('Invalid skipBlank threshold (-1 to 255/65535) ' + tile.skipBlanks);
+      }
+    } else {
+      if (is.defined(tile.layout) && tile.layout === 'google') {
+        this.options.skipBlanks = 5;
+      } else {
+        this.options.skipBlanks = -1;
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "Daiz <taneli.vatanen@gmail.com>",
     "Julian Aubourg <j@ubourg.net>",
     "Keith Belovay <keith@picthrive.com>",
-    "Michael B. Klein <mbklein@gmail.com>"
+    "Michael B. Klein <mbklein@gmail.com>",
+    "Jordan Prudhomme <jordan@raboland.fr>"
   ],
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node-gyp rebuild && node install/dll-copy)",

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -965,7 +965,8 @@ class PipelineWorker : public Nan::AsyncWorker {
                                        ->set("container", baton->tileContainer)
                                        ->set("layout", baton->tileLayout)
                                        ->set("suffix", const_cast<char*>(suffix.data()))
-                                       ->set("angle", CalculateAngleRotation(baton->tileAngle));
+                                       ->set("angle", CalculateAngleRotation(baton->tileAngle))
+                                       ->set("skip-blanks", baton->skipBlanks);
 
           // libvips chooses a default depth based on layout. Instead of replicating that logic here by
           // not passing anything - libvips will handle choice
@@ -1371,6 +1372,7 @@ NAN_METHOD(pipeline) {
   baton->tileOverlap = AttrTo<uint32_t>(options, "tileOverlap");
   std::string tileContainer = AttrAsStr(options, "tileContainer");
   baton->tileAngle = AttrTo<int32_t>(options, "tileAngle");
+  baton->skipBlanks = AttrTo<int32_t>(options, "skipBlanks");
   if (tileContainer == "zip") {
     baton->tileContainer = VIPS_FOREIGN_DZ_CONTAINER_ZIP;
   } else {

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -172,6 +172,7 @@ struct PipelineBaton {
   VipsForeignDzLayout tileLayout;
   std::string tileFormat;
   int tileAngle;
+  int skipBlanks;
   VipsForeignDzDepth tileDepth;
   std::unique_ptr<double[]> recombMatrix;
 
@@ -271,6 +272,7 @@ struct PipelineBaton {
     tileContainer(VIPS_FOREIGN_DZ_CONTAINER_FS),
     tileLayout(VIPS_FOREIGN_DZ_LAYOUT_DZ),
     tileAngle(0),
+    skipBlanks(-1),
     tileDepth(VIPS_FOREIGN_DZ_DEPTH_LAST) {}
 };
 


### PR DESCRIPTION
Hi!

Here it is ! 

* I didn't upgrade the libvips in the package.json version
* It seems that upgrade libvips to 8.8.0 broke 2 tests (`Image metadata ->  JPEG with IPTC/XMP` and `Attention strategy -> JPEG`) It also appears with master when libvips 8.8.0 is activated. I didn't fix them because i don't underestand their purposes ...
* I had to force the the skipBlanks in output.js because `AttrTo<int32_t>(options, "skipBlanks")` return 0 if it's NULL/undefined

Let me know if it needs some modifications.