### PR TITLE
Have toFormat accept heic/heif (#1824)

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -487,6 +487,17 @@ function raw () {
   return this._updateFormatOut('raw');
 }
 
+const formats = new Map([
+  ['heic', 'heif'],
+  ['heif', 'heif'],
+  ['jpeg', 'jpeg'],
+  ['jpg', 'jpeg'],
+  ['png', 'png'],
+  ['raw', 'raw'],
+  ['tiff', 'tiff'],
+  ['webp', 'webp']
+]);
+
 /**
  * Force output to a given format.
  *
@@ -502,14 +513,11 @@ function raw () {
  * @throws {Error} unsupported format or options
  */
 function toFormat (format, options) {
-  if (is.object(format) && is.string(format.id)) {
-    format = format.id;
+  const actualFormat = formats.get(is.object(format) && is.string(format.id) ? format.id : format);
+  if (!actualFormat) {
+    throw is.invalidParameterError('format', `one of: ${[...formats.keys()].join(`, `)}`, format);
   }
-  if (format === 'jpg') format = 'jpeg';
-  if (!is.inArray(format, ['jpeg', 'png', 'webp', 'tiff', 'raw'])) {
-    throw is.invalidParameterError('format', 'one of: jpeg, png, webp, tiff, raw', format);
-  }
-  return this[format](options);
+  return this[actualFormat](options);
 }
 
 /**


### PR DESCRIPTION
I used a Map instance to store format correspondances. Seemed to make eveything a bit clearer.