### PR TITLE
add installing with permissions tip to install doc

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -4,6 +4,9 @@
 npm install sharp
 ```
 
+If you are having permissions error while attempting to install globally,
+try `npm install -g --unsafe-perm sharp` or `npm config set user root` then `npm install -g sharp`.
+
 ```sh
 yarn add sharp
 ```


### PR DESCRIPTION
Users trying to install sharp globally or installing parent packages globally with sharp as a dependency typically runs into permissions error.

Therefore, I'm requesting permission (ah more permission blockers haha) to add this note to install.md.