### PR TITLE
Ensure tiles have overlap applied

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -575,7 +575,7 @@ function tile (options) {
         if (options.overlap > this.options.tileSize) {
           throw is.invalidParameterError('overlap', `<= size (${this.options.tileSize})`, options.overlap);
         }
-        this.options.tileOverlap = tile.overlap;
+        this.options.tileOverlap = options.overlap;
       } else {
         throw is.invalidParameterError('overlap', 'integer between 0 and 8192', options.overlap);
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "Jordan Prudhomme <jordan@raboland.fr>",
     "Ilya Ovdin <iovdin@gmail.com>",
     "Andargor <andargor@yahoo.com>",
-    "Paul Neave <paul.neave@gmail.com>"
+    "Paul Neave <paul.neave@gmail.com>",
+    "Brendan Kennedy <brenwken@gmail.com>"
   ],
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node-gyp rebuild && node install/dll-copy)",

--- a/test/unit/tile.js
+++ b/test/unit/tile.js
@@ -118,7 +118,6 @@ const assertTileOverlap = function (directory, tileSize) {
           assert.strictEqual(true, metadata.width > tileSize);
           assert.strictEqual(true, metadata.height > tileSize);
         }
-
         done();
       }
     });
@@ -331,7 +330,7 @@ describe('Tile', function () {
           assert.strictEqual(2225, info.height);
           assert.strictEqual(3, info.channels);
           assert.strictEqual('undefined', typeof info.size);
-          assertTileOverlap(directory, 512, 16);
+          assertTileOverlap(directory, 512);
           assertDeepZoomTiles(directory, 512 + (2 * 16), 13, done);
         });
     });

--- a/test/unit/tile.js
+++ b/test/unit/tile.js
@@ -92,7 +92,7 @@ const assertGoogleTiles = function (directory, expectedTileSize, expectedLevels,
 };
 
 // Verifies tiles at specified level in a given output directory are > size+overlap
-const assertTileOverlap = function (directory, tileSize) {
+const assertTileOverlap = function (directory, tileSize, done) {
   // Get sorted levels
   const levels = fs.readdirSync(directory).sort((a, b) => a - b);
   // Select the highest tile level
@@ -109,6 +109,7 @@ const assertTileOverlap = function (directory, tileSize) {
       // Tile with an overlap should be larger than original size
       assert.strictEqual(true, metadata.width > tileSize);
       assert.strictEqual(true, metadata.height > tileSize);
+      done();
     }
   });
 };
@@ -319,8 +320,9 @@ describe('Tile', function () {
           assert.strictEqual(2225, info.height);
           assert.strictEqual(3, info.channels);
           assert.strictEqual('undefined', typeof info.size);
-          assertTileOverlap(directory, 512);
-          assertDeepZoomTiles(directory, 512 + (2 * 16), 13, done);
+          assertDeepZoomTiles(directory, 512 + (2 * 16), 13, function () {
+            assertTileOverlap(directory, 512, done);
+          });
         });
     });
   });


### PR DESCRIPTION
This merge request addresses #1918, a tile overlap regression spotted in `v0.23.0` and higher.

I've made the change needed to fix the regression, I've also added a test to prevent it from happening again.

Let me know if there are any improvements that I can make, this is my first PR for Sharp!