### PR TITLE
FreeBSD uses stat instead of stat64

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -38,7 +38,7 @@
 #elif defined(__APPLE__)
 #define STAT64_STRUCT stat
 #define STAT64_FUNCTION stat
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 #define STAT64_STRUCT stat
 #define STAT64_FUNCTION stat
 #else

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -38,6 +38,9 @@
 #elif defined(__APPLE__)
 #define STAT64_STRUCT stat
 #define STAT64_FUNCTION stat
+#elif defined(__FreeBSD__)
+#define STAT64_STRUCT stat
+#define STAT64_FUNCTION stat
 #else
 #define STAT64_STRUCT stat64
 #define STAT64_FUNCTION stat64


### PR DESCRIPTION
`stat64` does not exist on FreeBSD.