### PR TITLE
Correctly bind max width and height values when using withoutEnlargement

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "Ilya Ovdin <iovdin@gmail.com>",
     "Andargor <andargor@yahoo.com>",
     "Paul Neave <paul.neave@gmail.com>",
-    "Brendan Kennedy <brenwken@gmail.com>"
+    "Brendan Kennedy <brenwken@gmail.com>",
+    "Brychan Bennett-Odlum <git@brychan.io>"
   ],
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node-gyp rebuild && node install/dll-copy)",

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -134,6 +134,17 @@ class PipelineWorker : public Nan::AsyncWorker {
         std::swap(inputWidth, inputHeight);
       }
 
+      // If withoutEnlargement is specified,
+      // Override target width and height if exceeds respective value from input file
+      if (baton->withoutEnlargement) {
+        if (baton->width > inputWidth) {
+          baton->width = inputWidth;
+        }
+        if (baton->height > inputHeight) {
+          baton->height = inputHeight;
+        }
+      }
+
       // Scaling calculations
       double xfactor = 1.0;
       double yfactor = 1.0;
@@ -220,21 +231,6 @@ class PipelineWorker : public Nan::AsyncWorker {
       // Calculate residual float affine transformation
       double xresidual = static_cast<double>(xshrink) / xfactor;
       double yresidual = static_cast<double>(yshrink) / yfactor;
-
-      // Do not enlarge the output if the input width *or* height
-      // are already less than the required dimensions
-      if (baton->withoutEnlargement) {
-        if (inputWidth < baton->width || inputHeight < baton->height) {
-          xfactor = 1.0;
-          yfactor = 1.0;
-          xshrink = 1;
-          yshrink = 1;
-          xresidual = 1.0;
-          yresidual = 1.0;
-          baton->width = inputWidth;
-          baton->height = inputHeight;
-        }
-      }
 
       // If integral x and y shrink are equal, try to use shrink-on-load for JPEG and WebP,
       // but not when applying gamma correction, pre-resize extract or trim

--- a/test/unit/resize.js
+++ b/test/unit/resize.js
@@ -307,6 +307,40 @@ describe('Resize dimensions', function () {
       });
   });
 
+  it('Do crop when fit = cover and withoutEnlargement = true and width >= outputWidth, and height < outputHeight', function (done) {
+    sharp(fixtures.inputJpg)
+      .resize({
+        width: 3000,
+        height: 1000,
+        withoutEnlargement: true
+      })
+      .toBuffer(function (err, data, info) {
+        if (err) throw err;
+        assert.strictEqual(true, data.length > 0);
+        assert.strictEqual('jpeg', info.format);
+        assert.strictEqual(2725, info.width);
+        assert.strictEqual(1000, info.height);
+        done();
+      });
+  });
+
+  it('Do crop when fit = cover and withoutEnlargement = true and width < outputWidth, and height >= outputHeight', function (done) {
+    sharp(fixtures.inputJpg)
+      .resize({
+        width: 1500,
+        height: 2226,
+        withoutEnlargement: true
+      })
+      .toBuffer(function (err, data, info) {
+        if (err) throw err;
+        assert.strictEqual(true, data.length > 0);
+        assert.strictEqual('jpeg', info.format);
+        assert.strictEqual(1500, info.width);
+        assert.strictEqual(2225, info.height);
+        done();
+      });
+  });
+
   it('Do enlarge when input width is less than output width', function (done) {
     sharp(fixtures.inputJpg)
       .resize({


### PR DESCRIPTION
Fix re #2020

When the `withoutEnlargement` option is set to true the pipeline *should* now bind the input image's width and height as maximum.

Previously if one value was in bounds and one was out of bounds, then the output image would keep the dimensions of the input image.

Also added two unit tests to back this.