### PR TITLE
Clarify stats.isOpaque

### DIFF
--- a/docs/api-input.md
+++ b/docs/api-input.md
@@ -68,7 +68,7 @@ A `Promise` is returned when `callback` is not provided.
     -   `minY` (y-coordinate of one of the pixel where the minimum lies)
     -   `maxX` (x-coordinate of one of the pixel where the maximum lies)
     -   `maxY` (y-coordinate of one of the pixel where the maximum lies)
--   `isOpaque`: Value to identify if the image is opaque or transparent, based on the presence and use of alpha channel
+-   `isOpaque`: Is the image fully opaque? Will be `true` if the image has no alpha channel or if every pixel is fully opaque.
 -   `entropy`: Histogram-based estimation of greyscale entropy, discarding alpha channel if any (experimental)
 
 ### Parameters

--- a/docs/api-input.md
+++ b/docs/api-input.md
@@ -68,7 +68,7 @@ A `Promise` is returned when `callback` is not provided.
     -   `minY` (y-coordinate of one of the pixel where the minimum lies)
     -   `maxX` (x-coordinate of one of the pixel where the maximum lies)
     -   `maxY` (y-coordinate of one of the pixel where the maximum lies)
--   `isOpaque`: Is the image fully opaque? Will be `true` if the image has no alpha channel or if every pixel is fully opaque.
+-   `isOpaque`: Value to identify if the image is opaque or transparent, based on the presence and use of alpha channel
 -   `entropy`: Histogram-based estimation of greyscale entropy, discarding alpha channel if any (experimental)
 
 ### Parameters

--- a/lib/input.js
+++ b/lib/input.js
@@ -278,7 +278,7 @@ function metadata (callback) {
  *     - `minY` (y-coordinate of one of the pixel where the minimum lies)
  *     - `maxX` (x-coordinate of one of the pixel where the maximum lies)
  *     - `maxY` (y-coordinate of one of the pixel where the maximum lies)
- * - `isOpaque`: Value to identify if the image is opaque or transparent, based on the presence and use of alpha channel
+ * - `isOpaque`: Is the image fully opaque? Will be `true` if the image has no alpha channel or if every pixel is fully opaque.
  * - `entropy`: Histogram-based estimation of greyscale entropy, discarding alpha channel if any (experimental)
  *
  * @example


### PR DESCRIPTION
It's hard to tell from the docs whether `stats.isOpaque` means that all pixels are 100% opaque, or if it means at least one pixel is not 100% transparent.