### PR TITLE
Added N-API badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ readableStream
 ```
 
 [![Test Coverage](https://coveralls.io/repos/lovell/sharp/badge.svg?branch=master)](https://coveralls.io/r/lovell/sharp?branch=master)
+![N-API v3 Badge](https://img.shields.io/badge/N--API-v3-green.svg)
 
 ### Documentation
 


### PR DESCRIPTION
I provided to add the N-API badge to the readme. This could help to identify your native addon as supporting N-API.
See: https://github.com/nodejs/abi-stable-node#badges