### PR TITLE
Adding a scale-down resize option

### DIFF
--- a/lib/resize.js
+++ b/lib/resize.js
@@ -69,7 +69,8 @@ const fit = {
   cover: 'cover',
   fill: 'fill',
   inside: 'inside',
-  outside: 'outside'
+  outside: 'outside',
+  scaledown: 'scaledown'
 };
 
 /**
@@ -82,7 +83,8 @@ const mapFitToCanvas = {
   cover: 'crop',
   fill: 'ignore_aspect',
   inside: 'max',
-  outside: 'min'
+  outside: 'min',
+  scaledown: 'scale_down'
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "Andargor <andargor@yahoo.com>",
     "Paul Neave <paul.neave@gmail.com>",
     "Brendan Kennedy <brenwken@gmail.com>",
-    "Brychan Bennett-Odlum <git@brychan.io>"
+    "Brychan Bennett-Odlum <git@brychan.io>",
+    "Doug Wehmeier <dougw@storyhunter.com>"
   ],
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install --runtime=napi) || (node-gyp rebuild && node install/dll-copy)",

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -178,6 +178,19 @@ class PipelineWorker : public Napi::AsyncWorker {
               std::swap(xfactor, yfactor);
             }
             break;
+          case Canvas::SCALE_DOWN:
+            if (xfactor <= 1.0 && yfactor <= 1.0) {
+              // Identity transform
+              baton->width = inputWidth;
+              baton->height = inputHeight;
+            } else if (xfactor > yfactor) {
+              targetResizeHeight = static_cast<int>(round(static_cast<double>(inputHeight) / xfactor));
+              yfactor = xfactor;
+            } else {
+              targetResizeWidth = static_cast<int>(round(static_cast<double>(inputWidth) / yfactor));
+              xfactor = yfactor;
+            }
+            break;
         }
       } else if (baton->width > 0) {
         // Fixed width
@@ -1174,6 +1187,8 @@ Napi::Value pipeline(const Napi::CallbackInfo& info) {
     baton->canvas = Canvas::MIN;
   } else if (canvas == "ignore_aspect") {
     baton->canvas = Canvas::IGNORE_ASPECT;
+  } else if (canvas == "scale_down") {
+    baton->canvas = Canvas::SCALE_DOWN;
   }
   // Tint chroma
   baton->tintA = sharp::AttrAsDouble(options, "tintA");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -31,7 +31,8 @@ enum class Canvas {
   EMBED,
   MAX,
   MIN,
-  IGNORE_ASPECT
+  IGNORE_ASPECT,
+  SCALE_DOWN
 };
 
 struct Composite {

--- a/test/unit/resize.js
+++ b/test/unit/resize.js
@@ -275,6 +275,32 @@ describe('Resize dimensions', function () {
       });
   });
 
+  it('fit=scaledown, greater', function (done) {
+    sharp(fixtures.inputJpg)
+      .resize(320, 320, { fit: sharp.fit.scaledown })
+      .toBuffer(function (err, data, info) {
+        if (err) throw err;
+        assert.strictEqual(true, data.length > 0);
+        assert.strictEqual('jpeg', info.format);
+        assert.strictEqual(320, info.width);
+        assert.strictEqual(261, info.height);
+        done();
+      });
+  });
+
+  it('fit=scaledown, lesser', function (done) {
+    sharp(fixtures.inputJpg)
+      .resize(3000, 3000, { fit: sharp.fit.scaledown })
+      .toBuffer(function (err, data, info) {
+        if (err) throw err;
+        assert.strictEqual(true, data.length > 0);
+        assert.strictEqual('jpeg', info.format);
+        assert.strictEqual(2725, info.width);
+        assert.strictEqual(2225, info.height);
+        done();
+      });
+  });
+
   it('Do not enlarge when input width is already less than output width', function (done) {
     sharp(fixtures.inputJpg)
       .resize({


### PR DESCRIPTION
I have a use case where I need to scale down the image when it is larger, and keep it the same when it is smaller than the target dimensions.  This is an offered scaling type in the CSS object-fit api that is loosely followed (https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).

Seems like a pretty simple addition, let me know what you think.