### PR TITLE
docs(clone): add promise example

### DIFF
--- a/docs/api-constructor.md
+++ b/docs/api-constructor.md
@@ -89,6 +89,57 @@ readableStream.pipe(pipeline);
 // secondWritableStream receives auto-rotated, extracted region of readableStream
 ```
 
+```javascript
+// Create a pipeline that will download an image, resize it and format it to different files
+// Using Promises to know when the pipeline is complete
+const fs = require("fs");
+const got = require("got");
+const sharpStream = sharp({
+  failOnError: false
+});
+
+const promises = [];
+
+promises.push(
+  sharpStream
+    .clone()
+    .jpeg({ quality: 100 })
+    .toFile("originalFile.jpg")
+);
+
+promises.push(
+  sharpStream
+    .clone()
+    .resize({ width: 500 })
+    .jpeg({ quality: 80 })
+    .toFile("optimized-500.jpg")
+);
+
+promises.push(
+  sharpStream
+    .clone()
+    .resize({ width: 500 })
+    .webp({ quality: 80 })
+    .toFile("optimized-500.webp")
+);
+
+// https://github.com/sindresorhus/got#gotstreamurl-options
+got.stream("https://www.example.com/some-file.jpg").pipe(sharpStream);
+
+fs.createReadStream(jpgOriginalImagePath).pipe(sharpStream);
+
+Promise.all(promises)
+  .then(res => { console.log("Done!", res); })
+  .catch(err => {
+    console.error("Error processing files, let's clean it up", err);
+    try {
+      fs.unlinkSync("originalFile.jpg");
+      fs.unlinkSync("optimized-500.jpg");
+      fs.unlinkSync("optimized-500.webp");
+    }
+  });
+```
+
 Returns **[Sharp][8]** 
 
 [1]: https://nodejs.org/api/buffer.html

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -253,6 +253,54 @@ util.inherits(Sharp, stream.Duplex);
  * // firstWritableStream receives auto-rotated, resized readableStream
  * // secondWritableStream receives auto-rotated, extracted region of readableStream
  *
+ * @example
+ * // Create a pipeline that will download an image, resize it and format it to different files
+ * // Using Promises to know when the pipeline is complete
+ * const fs = require("fs");
+ * const got = require("got");
+ * const sharpStream = sharp({
+ *   failOnError: false
+ * });
+ *
+ * const promises = [];
+ *
+ * promises.push(
+ *   sharpStream
+ *     .clone()
+ *     .jpeg({ quality: 100 })
+ *     .toFile("originalFile.jpg")
+ * );
+ *
+ * promises.push(
+ *   sharpStream
+ *     .clone()
+ *     .resize({ width: 500 })
+ *     .jpeg({ quality: 80 })
+ *     .toFile("optimized-500.jpg")
+ * );
+ *
+ * promises.push(
+ *   sharpStream
+ *     .clone()
+ *     .resize({ width: 500 })
+ *     .webp({ quality: 80 })
+ *     .toFile("optimized-500.webp")
+ * );
+ *
+ * // https://github.com/sindresorhus/got#gotstreamurl-options
+ * got.stream("https://www.example.com/some-file.jpg").pipe(sharpStream);
+ *
+ * Promise.all(promises)
+ *   .then(res => { console.log("Done!", res); })
+ *   .catch(err => {
+ *     console.error("Error processing files, let's clean it up", err);
+ *     try {
+ *       fs.unlinkSync("originalFile.jpg");
+ *       fs.unlinkSync("optimized-500.jpg");
+ *       fs.unlinkSync("optimized-500.webp");
+ *     } catch (e) {}
+ *   });
+ *
  * @returns {Sharp}
  */
 function clone () {


### PR DESCRIPTION
It took me some time to figure out how to properly create a pipeline and know
when it's done, while https://github.com/lovell/sharp/issues/524 provides an
example about listening to the finish event, I needed one for toFile.

Now I think we should also document the example from
https://github.com/lovell/sharp/issues/524 but I'd like you the maintainer to
create it because I am not 100% sure this is the most elegant way.

Thanks for the awesome library! It helped me build this: https://coronamaison.net/ (https://github.com/vvo/coronamaison/blob/549a807aea1e2034a0a5821dff6ea89488be46a3/prepareData.js#L153)