### PR TITLE
docs: change 'colourspace' to 'toColourspace'

### DIFF
--- a/docs/api-output.md
+++ b/docs/api-output.md
@@ -314,7 +314,7 @@ const { data, info } = await sharp('input.jpg')
 const data = await sharp('input.png')
   .ensureAlpha()
   .extractChannel(3)
-  .colourspace('b-w')
+  .toColourspace('b-w')
   .raw()
   .toBuffer();
 ```

--- a/lib/output.js
+++ b/lib/output.js
@@ -532,7 +532,7 @@ function heif (options) {
  * const data = await sharp('input.png')
  *   .ensureAlpha()
  *   .extractChannel(3)
- *   .colourspace('b-w')
+ *   .toColourspace('b-w')
  *   .raw()
  *   .toBuffer();
  *


### PR DESCRIPTION
Came across this while updating the typings for DefinitelyTyped, in the example for `.raw()` the method `.colourspace()` is called, which I think should be `.toColourspace()` instead?