### PR TITLE
ISSUE 2105: Added the possibility to set the host for downloading the binary

### DIFF
--- a/install/libvips.js
+++ b/install/libvips.js
@@ -21,7 +21,7 @@ const minimumGlibcVersionByArch = {
 };
 
 const { minimumLibvipsVersion, minimumLibvipsVersionLabelled } = libvips;
-const distHost = process.env.npm_config_sharp_libvips_binary_host || process.env.npm_config_sharp_libvips_binary_host_mirror || `https://github.com/lovell/sharp-libvips/releases/download/`;
+const distHost = process.env.npm_config_sharp_libvips_binary_host || process.env.npm_config_sharp_libvips_binary_host_mirror || 'https://github.com/lovell/sharp-libvips/releases/download/';
 const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || distHost + `/v${minimumLibvipsVersionLabelled}/`;
 
 const fail = function (err) {

--- a/install/libvips.js
+++ b/install/libvips.js
@@ -21,8 +21,8 @@ const minimumGlibcVersionByArch = {
 };
 
 const { minimumLibvipsVersion, minimumLibvipsVersionLabelled } = libvips;
-const distHost = process.env.npm_config_sharp_libvips_binary_host || process.env.npm_config_sharp_libvips_binary_host_mirror || `https://github.com/lovell/sharp-libvips/releases/`;
-const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || distHost + `/download/v${minimumLibvipsVersionLabelled}/`;
+const distHost = process.env.npm_config_sharp_libvips_binary_host || process.env.npm_config_sharp_libvips_binary_host_mirror || `https://github.com/lovell/sharp-libvips/releases/download/`;
+const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || distHost + `/v${minimumLibvipsVersionLabelled}/`;
 
 const fail = function (err) {
   npmLog.error('sharp', err.message);

--- a/install/libvips.js
+++ b/install/libvips.js
@@ -21,7 +21,8 @@ const minimumGlibcVersionByArch = {
 };
 
 const { minimumLibvipsVersion, minimumLibvipsVersionLabelled } = libvips;
-const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || `https://github.com/lovell/sharp-libvips/releases/download/v${minimumLibvipsVersionLabelled}/`;
+const distHost = process.env.npm_config_sharp_libvips_binary_host || process.env.npm_config_sharp_libvips_binary_host_mirror || `https://github.com/lovell/sharp-libvips/releases/`;
+const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || distHost + `/download/v${minimumLibvipsVersionLabelled}/`;
 
 const fail = function (err) {
   npmLog.error('sharp', err.message);


### PR DESCRIPTION
ISSUE 2105: Added the possibility to set the host for downloading the binary in a way similar to 'prebuild' and 'node-pre-gyp'.

Left in the previous additions using 'sharp_dist_base_url' and 'SHARP_DIST_BASE_URL' to not break working installations.