### PR TITLE
Add support for statically-linked dependencies (lovell/sharp-libvips#39)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,6 @@
 {
   'variables': {
-    'vips_version': '8.9.2',
+    'vips_version': '<!(node -p "require(\'./lib/libvips\').minimumLibvipsVersion")',
     'sharp_vendor_dir': '<(module_root_dir)/vendor/<(vips_version)'
   },
   'targets': [{
@@ -77,8 +77,8 @@
       'runtime_link%': 'shared',
       'conditions': [
         ['OS != "win"', {
-          'pkg_config_path': '<!(node -e "console.log(require(\'./lib/libvips\').pkgConfigPath())")',
-          'use_global_libvips': '<!(node -e "console.log(Boolean(require(\'./lib/libvips\').useGlobalLibvips()).toString())")'
+          'pkg_config_path': '<!(node -p "require(\'./lib/libvips\').pkgConfigPath()")',
+          'use_global_libvips': '<!(node -p "Boolean(require(\'./lib/libvips\').useGlobalLibvips()).toString()")'
         }, {
           'pkg_config_path': '',
           'use_global_libvips': ''

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,8 @@
 {
+  'variables': {
+    'vips_version': '8.9.2',
+    'sharp_vendor_dir': '<(module_root_dir)/vendor/<(vips_version)'
+  },
   'targets': [{
     'target_name': 'libvips-cpp',
     'conditions': [
@@ -16,15 +20,18 @@
           'src/libvips/cplusplus/VImage.cpp'
         ],
         'include_dirs': [
-          'vendor/include',
-          'vendor/include/glib-2.0',
-          'vendor/lib/glib-2.0/include'
+          '<(sharp_vendor_dir)/include',
+          '<(sharp_vendor_dir)/include/glib-2.0',
+          '<(sharp_vendor_dir)/lib/glib-2.0/include'
         ],
-        'libraries': [
-          '../vendor/lib/libvips.lib',
-          '../vendor/lib/libglib-2.0.lib',
-          '../vendor/lib/libgobject-2.0.lib'
-        ],
+        'link_settings': {
+          'library_dirs': ['<(sharp_vendor_dir)/lib'],
+          'libraries': [
+            'libvips.lib',
+            'libglib-2.0.lib',
+            'libgobject-2.0.lib'
+          ],
+        },
         'configurations': {
           'Release': {
             'msvs_settings': {
@@ -110,9 +117,9 @@
       }, {
         # Use pre-built libvips stored locally within node_modules
         'include_dirs': [
-          'vendor/include',
-          'vendor/include/glib-2.0',
-          'vendor/lib/glib-2.0/include'
+          '<(sharp_vendor_dir)/include',
+          '<(sharp_vendor_dir)/include/glib-2.0',
+          '<(sharp_vendor_dir)/lib/glib-2.0/include'
         ],
         'conditions': [
           ['OS == "win"', {
@@ -120,64 +127,45 @@
               '_ALLOW_KEYWORD_MACROS',
               '_FILE_OFFSET_BITS=64'
             ],
-            'libraries': [
-              '../vendor/lib/libvips.lib',
-              '../vendor/lib/libglib-2.0.lib',
-              '../vendor/lib/libgobject-2.0.lib'
-            ]
+            'link_settings': {
+              'library_dirs': ['<(sharp_vendor_dir)/lib'],
+              'libraries': [
+                'libvips.lib',
+                'libglib-2.0.lib',
+                'libgobject-2.0.lib'
+              ]
+            }
           }],
           ['OS == "mac"', {
-            'libraries': [
-              '../vendor/lib/libvips-cpp.42.dylib',
-              '../vendor/lib/libvips.42.dylib',
-              '../vendor/lib/libglib-2.0.0.dylib',
-              '../vendor/lib/libgobject-2.0.0.dylib',
-              # Ensure runtime linking is relative to sharp.node
-              '-rpath \'@loader_path/../../vendor/lib\''
-            ]
+            'link_settings': {
+              'library_dirs': ['<(sharp_vendor_dir)/lib'],
+              'libraries': [
+                'libvips-cpp.42.dylib',
+                'libvips.42.dylib'
+              ]
+            },
+            'xcode_settings': {
+              'OTHER_LDFLAGS': [
+                # Ensure runtime linking is relative to sharp.node
+                '-Wl,-rpath,\'@loader_path/../../vendor/<(vips_version)/lib\''
+              ]
+            }
           }],
           ['OS == "linux"', {
             'defines': [
               '_GLIBCXX_USE_CXX11_ABI=0'
             ],
-            'libraries': [
-              '../vendor/lib/libvips-cpp.so',
-              '../vendor/lib/libvips.so',
-              '../vendor/lib/libglib-2.0.so',
-              '../vendor/lib/libgobject-2.0.so',
-              # Dependencies of dependencies, included for openSUSE support
-              '../vendor/lib/libcairo.so',
-              '../vendor/lib/libexif.so',
-              '../vendor/lib/libexpat.so',
-              '../vendor/lib/libffi.so',
-              '../vendor/lib/libfontconfig.so',
-              '../vendor/lib/libfreetype.so',
-              '../vendor/lib/libfribidi.so',
-              '../vendor/lib/libgdk_pixbuf-2.0.so',
-              '../vendor/lib/libgif.so',
-              '../vendor/lib/libgio-2.0.so',
-              '../vendor/lib/libgmodule-2.0.so',
-              '../vendor/lib/libgsf-1.so',
-              '../vendor/lib/libgthread-2.0.so',
-              '../vendor/lib/libharfbuzz.so',
-              '../vendor/lib/libjpeg.so',
-              '../vendor/lib/liblcms2.so',
-              '../vendor/lib/liborc-0.4.so',
-              '../vendor/lib/libpango-1.0.so',
-              '../vendor/lib/libpangocairo-1.0.so',
-              '../vendor/lib/libpangoft2-1.0.so',
-              '../vendor/lib/libpixman-1.so',
-              '../vendor/lib/libpng.so',
-              '../vendor/lib/librsvg-2.so',
-              '../vendor/lib/libtiff.so',
-              '../vendor/lib/libwebp.so',
-              '../vendor/lib/libwebpdemux.so',
-              '../vendor/lib/libwebpmux.so',
-              '../vendor/lib/libxml2.so',
-              '../vendor/lib/libz.so',
-              # Ensure runtime linking is relative to sharp.node
-              '-Wl,-s -Wl,--disable-new-dtags -Wl,-rpath=\'$${ORIGIN}/../../vendor/lib\''
-            ]
+            'link_settings': {
+              'library_dirs': ['<(sharp_vendor_dir)/lib'],
+              'libraries': [
+                '-l:libvips-cpp.so.42',
+                '-l:libvips.so.42'
+              ],
+              'ldflags': [
+                # Ensure runtime linking is relative to sharp.node
+                '-Wl,-s -Wl,--disable-new-dtags -Wl,-rpath=\'$$ORIGIN/../../vendor/<(vips_version)/lib\''
+              ]
+            }
           }]
         ]
       }]
@@ -190,8 +178,7 @@
     ],
     'xcode_settings': {
       'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
-      'CLANG_CXX_LIBRARY': 'libc++',
-      'MACOSX_DEPLOYMENT_TARGET': '10.7',
+      'MACOSX_DEPLOYMENT_TARGET': '10.9',
       'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
       'GCC_ENABLE_CPP_RTTI': 'YES',
       'OTHER_CPLUSPLUSFLAGS': [

--- a/install/dll-copy.js
+++ b/install/dll-copy.js
@@ -6,6 +6,8 @@ const path = require('path');
 const libvips = require('../lib/libvips');
 const npmLog = require('npmlog');
 
+const minimumLibvipsVersion = libvips.minimumLibvipsVersion;
+
 const platform = process.env.npm_config_platform || process.platform;
 if (platform === 'win32') {
   const buildDir = path.join(__dirname, '..', 'build');
@@ -15,7 +17,7 @@ if (platform === 'win32') {
     libvips.mkdirSync(buildDir);
     libvips.mkdirSync(buildReleaseDir);
   } catch (err) {}
-  const vendorLibDir = path.join(__dirname, '..', 'vendor', 'lib');
+  const vendorLibDir = path.join(__dirname, '..', 'vendor', minimumLibvipsVersion, 'lib');
   npmLog.info('sharp', `Copying DLLs from ${vendorLibDir} to ${buildReleaseDir}`);
   try {
     fs

--- a/install/libvips.js
+++ b/install/libvips.js
@@ -37,10 +37,12 @@ const fail = function (err) {
 const extractTarball = function (tarPath) {
   const vendorPath = path.join(__dirname, '..', 'vendor');
   libvips.mkdirSync(vendorPath);
+  const versionedVendorPath = path.join(vendorPath, minimumLibvipsVersion);
+  libvips.mkdirSync(versionedVendorPath);
   tar
     .extract({
       file: tarPath,
-      cwd: vendorPath,
+      cwd: versionedVendorPath,
       strict: true
     })
     .catch(function (err) {

--- a/lib/libvips.js
+++ b/lib/libvips.js
@@ -48,17 +48,11 @@ const globalLibvipsVersion = function () {
 
 const hasVendoredLibvips = function () {
   const currentPlatformId = platform();
-  const vendorPath = path.join(__dirname, '..', 'vendor');
-  let vendorVersionId;
+  const vendorPath = path.join(__dirname, '..', 'vendor', minimumLibvipsVersion);
   let vendorPlatformId;
   try {
-    vendorVersionId = require(path.join(vendorPath, 'versions.json')).vips;
     vendorPlatformId = require(path.join(vendorPath, 'platform.json'));
   } catch (err) {}
-  /* istanbul ignore if */
-  if (vendorVersionId && vendorVersionId !== minimumLibvipsVersion) {
-    throw new Error(`Found vendored libvips v${vendorVersionId} but require v${minimumLibvipsVersion}. Please remove the 'node_modules/sharp/vendor' directory and run 'npm install'.`);
-  }
   /* istanbul ignore else */
   if (vendorPlatformId) {
     /* istanbul ignore else */

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -23,7 +23,7 @@ let versions = {
   vips: sharp.libvipsVersion()
 };
 try {
-  versions = require('../vendor/versions.json');
+  versions = require(`../vendor/${versions.vips}/versions.json`);
 } catch (err) {}
 
 /**

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
   },
   "license": "Apache-2.0",
   "config": {
-    "libvips": "8.9.1"
+    "libvips": "8.9.2-alpha2"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
This PR adds supports for a single shared libvips library with its dependencies statically-linked as described in PR https://github.com/lovell/sharp-libvips/pull/44 and issue https://github.com/lovell/sharp-libvips/issues/39.

I've also included several other enhancements:
- Set the minimum macOS deployment target to 10.9 (Mavericks) which is a good balance between features and compatibility. Starting with 10.9, Apple has made libc++ the default, so it is no longer necessary to set `CLANG_CXX_LIBRARY`. Note that [Node v12 has set this variable to 10.10](https://github.com/nodejs/node/commit/a7d7d4dfb73233b23e478c73d6fff784a0738b9b).
- Link the dependencies with a fully-qualified soname (e.g. `libvips.so.42`) as the symbolic links in the tarball are dereferenced now.
- Unpack the prebuilt libvips binaries into a versioned directory.
- Move `library_dirs` and `libraries` to the `link_settings` section within `binding.gyp`, see: https://gyp.gsrc.io/docs/InputFormatReference.md#dependent-settings

Any help with testing would be much appreciated, testing can be done with:
```bash
npm install kleisauke/sharp#statically-linked
```

Note that the last commit must be reverted before merging. This commit is intended for CI testing purposes as the new tarballs have not yet been uploaded to https://github.com/lovell/sharp-libvips/releases.