### PR TITLE
Simplify check plaint object, buffer

### DIFF
--- a/lib/is.js
+++ b/lib/is.js
@@ -21,7 +21,7 @@ const object = function (val) {
  * @private
  */
 const plainObject = function (val) {
-  return object(val) && Object.prototype.toString.call(val) === '[object Object]';
+  return Object.prototype.toString.call(val) === '[object Object]';
 };
 
 /**
@@ -45,7 +45,7 @@ const bool = function (val) {
  * @private
  */
 const buffer = function (val) {
-  return object(val) && val instanceof Buffer;
+  return val instanceof Buffer;
 };
 
 /**


### PR DESCRIPTION
I just removed needless check for Object. `instance of` and `Object.prototype.toString.call` covered cases for non object value.