### PR TITLE
Allow page selection when loading a file through ImageMagick

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -252,6 +252,7 @@ namespace sharp {
   */
   bool ImageTypeSupportsPage(ImageType imageType) {
     return
+      imageType == ImageType::MAGICK ||
       imageType == ImageType::GIF ||
       imageType == ImageType::TIFF ||
       imageType == ImageType::HEIF ||


### PR DESCRIPTION
ICO files, for instance, may have multiple pages, which can be selected when loading a file through ImageMagick.