### PR TITLE
Partial objects should no longer fail

### DIFF
--- a/test/unit/extend.js
+++ b/test/unit/extend.js
@@ -64,9 +64,9 @@ describe('Extend', function () {
       sharp().extend(-1);
     });
   });
-  it('partial object fails', function () {
+  it('string object property fails', function () {
     assert.throws(function () {
-      sharp().extend({ top: 1 });
+      sharp().extend({ top: 1, bottom: "5" });
     });
   });
 


### PR DESCRIPTION
Extend now has unset values default to zero. Instead I made the test try a string number.