### PR TITLE
fix: Animated GIF to WEBP using a Sharp stream is not animated anymore

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -9,9 +9,9 @@ const sharp = require('../build/Release/sharp.node');
  * @private
  */
 function _inputOptionsFromObject (obj) {
-  const { raw, density, limitInputPixels, sequentialRead, failOnError } = obj;
-  return [raw, density, limitInputPixels, sequentialRead, failOnError].some(is.defined)
-    ? { raw, density, limitInputPixels, sequentialRead, failOnError }
+  const { raw, density, limitInputPixels, sequentialRead, failOnError, animated, page, pages } = obj;
+  return [raw, density, limitInputPixels, sequentialRead, failOnError, animated, page, pages].some(is.defined)
+    ? { raw, density, limitInputPixels, sequentialRead, failOnError, animated, page, pages }
     : undefined;
 }
 

--- a/test/unit/gif.js
+++ b/test/unit/gif.js
@@ -98,4 +98,36 @@ describe('GIF input', () => {
       sharp().gif({ delay: [65536] });
     });
   });
+
+  it('should work with streams when only animated is set', function (done) {
+    if (sharp.format.magick.output.buffer) {
+      fs.createReadStream(fixtures.inputGifAnimated)
+        .pipe(sharp({ animated: true }))
+        .gif()
+        .toBuffer(function (err, data, info) {
+          if (err) throw err;
+          assert.strictEqual(true, data.length > 0);
+          assert.strictEqual('gif', info.format);
+          fixtures.assertSimilar(fixtures.inputGifAnimated, data, done);
+        });
+    } else {
+      done();
+    }
+  });
+
+  it('should work with streams when only pages is set', function (done) {
+    if (sharp.format.magick.output.buffer) {
+      fs.createReadStream(fixtures.inputGifAnimated)
+        .pipe(sharp({ pages: -1 }))
+        .gif()
+        .toBuffer(function (err, data, info) {
+          if (err) throw err;
+          assert.strictEqual(true, data.length > 0);
+          assert.strictEqual('gif', info.format);
+          fixtures.assertSimilar(fixtures.inputGifAnimated, data, done);
+        });
+    } else {
+      done();
+    }
+  });
 });

--- a/test/unit/webp.js
+++ b/test/unit/webp.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const assert = require('assert');
 
 const sharp = require('../../');
@@ -183,5 +184,29 @@ describe('WebP', function () {
       .then(data => sharp(data, { pages: -1 }).metadata());
 
     assert.deepStrictEqual(updated.delay, expectedDelay);
+  });
+
+  it('should work with streams when only animated is set', function (done) {
+    fs.createReadStream(fixtures.inputWebPAnimated)
+      .pipe(sharp({ animated: true }))
+      .webp({ lossless: true })
+      .toBuffer(function (err, data, info) {
+        if (err) throw err;
+        assert.strictEqual(true, data.length > 0);
+        assert.strictEqual('webp', info.format);
+        fixtures.assertSimilar(fixtures.inputWebPAnimated, data, done);
+      });
+  });
+
+  it('should work with streams when only pages is set', function (done) {
+    fs.createReadStream(fixtures.inputWebPAnimated)
+      .pipe(sharp({ pages: -1 }))
+      .webp({ lossless: true })
+      .toBuffer(function (err, data, info) {
+        if (err) throw err;
+        assert.strictEqual(true, data.length > 0);
+        assert.strictEqual('webp', info.format);
+        fixtures.assertSimilar(fixtures.inputWebPAnimated, data, done);
+      });
   });
 });


### PR DESCRIPTION
Fixes #2362.
