### PR TITLE
Avoid install script crashing on Yarn

### DIFF
--- a/install/libvips.js
+++ b/install/libvips.js
@@ -56,13 +56,6 @@ const extractTarball = function (tarPath) {
   );
 };
 
-const getSupportedNodeVersion = () => {
-  const rawPackage = fs.readFileSync(path.join(__dirname, '..', 'package.json'), { encoding: 'utf8' });
-  const packageObj = JSON.parse(rawPackage);
-
-  return packageObj && packageObj.engines.node;
-};
-
 try {
   const useGlobalLibvips = libvips.useGlobalLibvips();
   if (useGlobalLibvips) {
@@ -87,7 +80,7 @@ try {
         throw new Error(`Use with glibc ${detectLibc.version} requires manual installation of libvips >= ${minimumLibvipsVersion}`);
       }
     }
-    const supportedNodeVersion = process.env.npm_package_engines_node || getSupportedNodeVersion();
+    const supportedNodeVersion = process.env.npm_package_engines_node || require('../package.json').engines.node;
     if (!supportedNodeVersion) {
       throw new Error('Couldn\'t read the package\'s supported Node version');
     }

--- a/install/libvips.js
+++ b/install/libvips.js
@@ -80,10 +80,8 @@ try {
         throw new Error(`Use with glibc ${detectLibc.version} requires manual installation of libvips >= ${minimumLibvipsVersion}`);
       }
     }
+
     const supportedNodeVersion = process.env.npm_package_engines_node || require('../package.json').engines.node;
-    if (!supportedNodeVersion) {
-      throw new Error('Couldn\'t read the package\'s supported Node version');
-    }
     if (!semver.satisfies(process.versions.node, supportedNodeVersion)) {
       throw new Error(`Expected Node.js version ${supportedNodeVersion} but found ${process.versions.node}`);
     }


### PR DESCRIPTION
The version check added in https://github.com/lovell/sharp/commit/d406cb619c9a9db336f138b58bfde267e573e1ce expects `process.env.npm_package_engines_node` to exist. Yarn 2 (not sure about v1) doesn't expose fields from `package.json` like `npm` does, so the build instantly fails, rendering 0.26.1 uninstallable.

I've added a fallback that reads and parses `package.json` directly if the expected variable isn't found.