### PR TITLE
Deps: Removed 'array-flatten' dependency

### DIFF
--- a/lib/operation.js
+++ b/lib/operation.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { flatten: flattenArray } = require('array-flatten');
 const color = require('color');
 const is = require('./is');
 
@@ -127,7 +126,7 @@ function flop (flop) {
  * @throws {Error} Invalid parameters
  */
 function affine (matrix, options) {
-  const flatMatrix = flattenArray(matrix);
+  const flatMatrix = matrix.flat();
   if (flatMatrix.length === 4 && flatMatrix.every(is.number)) {
     this.options.affineMatrix = flatMatrix;
   } else {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "vips"
   ],
   "dependencies": {
-    "array-flatten": "^3.0.0",
     "color": "^3.1.3",
     "detect-libc": "^1.0.3",
     "node-addon-api": "^3.0.2",


### PR DESCRIPTION
As described in #2489 , `array-flatten` can simply be replaced by Node's native `Array.flat`