### PR TITLE
Rr/tiff bitdepth

### DIFF
--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -227,7 +227,7 @@ const Sharp = function (input, options) {
     tiffCompression: 'jpeg',
     tiffPredictor: 'horizontal',
     tiffPyramid: false,
-    tiffBitdepth: 8,
+    tiffBitdepth: 4,
     tiffTile: false,
     tiffTileHeight: 256,
     tiffTileWidth: 256,

--- a/lib/output.js
+++ b/lib/output.js
@@ -494,10 +494,10 @@ function tiff (options) {
       }
     }
     if (is.defined(options.bitdepth)) {
-      if (is.integer(options.bitdepth) && is.inArray(options.bitdepth, [1, 2, 4, 8])) {
+      if (is.integer(options.bitdepth) && is.inArray(options.bitdepth, [1, 2, 4])) {
         this.options.tiffBitdepth = options.bitdepth;
       } else {
-        throw is.invalidParameterError('bitdepth', '1, 2, 4 or 8', options.bitdepth);
+        throw is.invalidParameterError('bitdepth', '1, 2, or 4', options.bitdepth);
       }
     }
     // tiling

--- a/lib/output.js
+++ b/lib/output.js
@@ -480,7 +480,7 @@ function trySetAnimationOptions (source, target) {
  * @param {boolean} [options.tileHeight=256] - vertical tile size
  * @param {number} [options.xres=1.0] - horizontal resolution in pixels/mm
  * @param {number} [options.yres=1.0] - vertical resolution in pixels/mm
- * @param {boolean} [options.bitdepth=8] - reduce bitdepth to 1, 2 or 4 bit
+ * @param {boolean} [options.bitdepth=4] - reduce bitdepth to 1, 2 or 4 bit
  * @returns {Sharp}
  * @throws {Error} Invalid options
  */

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -951,6 +951,10 @@ class PipelineWorker : public Napi::AsyncWorker {
             sharp::AssertImageTypeDimensions(image, sharp::ImageType::JPEG);
             baton->channels = std::min(baton->channels, 3);
           }
+          // Cast pixel values to float, if required
+          if (baton->tiffPredictor == VIPS_FOREIGN_TIFF_PREDICTOR_FLOAT) {
+            image = image.cast(VIPS_FORMAT_FLOAT);
+          }
           image.tiffsave(const_cast<char*>(baton->fileOut.data()), VImage::option()
             ->set("strip", !baton->withMetadata)
             ->set("Q", baton->tiffQuality)

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -273,7 +273,7 @@ struct PipelineBaton {
     tiffCompression(VIPS_FOREIGN_TIFF_COMPRESSION_JPEG),
     tiffPredictor(VIPS_FOREIGN_TIFF_PREDICTOR_HORIZONTAL),
     tiffPyramid(false),
-    tiffBitdepth(8),
+    tiffBitdepth(4),
     tiffTile(false),
     tiffTileHeight(256),
     tiffTileWidth(256),


### PR DESCRIPTION
It appears per [tiff_save](https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-tiffsave) that bitdepth here should be 1, 2, or 4, and not 8.  I receive a warning from libvips as such:

``` sh
(NetVips:12484): VIPS-WARNING **: 13:09:07.670: bitdepth 1, 2 or 4 only -- disabling bitdepth
```