### PR TITLE
Add support for a single shared library (#2535)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -140,8 +140,7 @@
             'link_settings': {
               'library_dirs': ['<(sharp_vendor_dir)/lib'],
               'libraries': [
-                'libvips-cpp.42.dylib',
-                'libvips.42.dylib'
+                'libvips-cpp.42.dylib'
               ]
             },
             'xcode_settings': {
@@ -158,8 +157,7 @@
             'link_settings': {
               'library_dirs': ['<(sharp_vendor_dir)/lib'],
               'libraries': [
-                '-l:libvips-cpp.so.42',
-                '-l:libvips.so.42'
+                '-l:libvips-cpp.so.42'
               ],
               'ldflags': [
                 # Ensure runtime linking is relative to sharp.node

--- a/install/libvips.js
+++ b/install/libvips.js
@@ -23,8 +23,8 @@ const minimumGlibcVersionByArch = {
 };
 
 const { minimumLibvipsVersion, minimumLibvipsVersionLabelled } = libvips;
-const distHost = process.env.npm_config_sharp_libvips_binary_host || 'https://github.com/lovell/sharp-libvips/releases/download';
-const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || `${distHost}/v${minimumLibvipsVersionLabelled}/`;
+const distHost = process.env.npm_config_sharp_libvips_binary_host || 'https://github.com/kleisauke/libvips-packaging/releases/download';
+const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || `${distHost}/v${minimumLibvipsVersionLabelled}-single-shared/`;
 const supportsBrotli = ('BrotliDecompress' in zlib);
 
 const fail = function (err) {


### PR DESCRIPTION
This PR adds supports for a single shared libvips library (i.e. `libvips.so.42` statically linked into `libvips-cpp.so.42`) as described in issue https://github.com/lovell/sharp/issues/2535 and PR https://github.com/lovell/sharp-libvips/pull/81.

Testing can be done with:
```bash
rm ~/.npm/_libvips/libvips-8.10.5-linux-x64.tar.br
SHARP_DIST_BASE_URL="https://github.com/kleisauke/libvips-packaging/releases/download/v8.10.5-single-shared/" \
  npm install kleisauke/sharp#single-shared
```

Depends on: https://github.com/lovell/sharp-libvips/pull/81.

(the last commit must be reverted before merging)