### PR TITLE
Docs: correct type for AVIF speed output option

### DIFF
--- a/docs/api-output.md
+++ b/docs/api-output.md
@@ -326,7 +326,7 @@ most web browsers do not display these properly.
 -   `options` **[Object][6]?** output options
     -   `options.quality` **[number][9]** quality, integer 1-100 (optional, default `50`)
     -   `options.lossless` **[boolean][7]** use lossless compression (optional, default `false`)
-    -   `options.speed` **[boolean][7]** CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest) (optional, default `5`)
+    -   `options.speed` **[number][9]** CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest) (optional, default `5`)
     -   `options.chromaSubsampling` **[string][2]** set to '4:4:4' to prevent chroma subsampling otherwise defaults to '4:2:0' chroma subsampling, requires libvips v8.11.0 (optional, default `'4:2:0'`)
 
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -582,7 +582,7 @@ function tiff (options) {
  * @param {Object} [options] - output options
  * @param {number} [options.quality=50] - quality, integer 1-100
  * @param {boolean} [options.lossless=false] - use lossless compression
- * @param {boolean} [options.speed=5] - CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest)
+ * @param {number} [options.speed=5] - CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest)
  * @param {string} [options.chromaSubsampling='4:2:0'] - set to '4:4:4' to prevent chroma subsampling otherwise defaults to '4:2:0' chroma subsampling, requires libvips v8.11.0
  * @returns {Sharp}
  * @throws {Error} Invalid options


### PR DESCRIPTION
Should be `number`.

Fixes issue: https://github.com/lovell/sharp/issues/2567