### PR TITLE
Change utility-related functions assignment way

### DIFF
--- a/lib/utility.js
+++ b/lib/utility.js
@@ -157,14 +157,10 @@ simd(true);
  * @private
  */
 module.exports = function (Sharp) {
-  [
-    cache,
-    concurrency,
-    counters,
-    simd
-  ].forEach(function (f) {
-    Sharp[f.name] = f;
-  });
+  Sharp.cache = cache;
+  Sharp.concurrency = concurrency;
+  Sharp.counters = counters;
+  Sharp.simd = simd;
   Sharp.format = format;
   Sharp.interpolators = interpolators;
   Sharp.versions = versions;


### PR DESCRIPTION
Some bundlers (in my case, rollup v2 with commonjs plugin) tend to rename lib variables for some reason like shown in the sample output code below:
```
/**
 * Decorate the Sharp class with utility-related functions.
 * @private
 */
var utility = function (Sharp) {
  [
    cache$1,
    concurrency,
    counters,
    simd
  ].forEach(function (f) {
    Sharp[f.name] = f;
  });
  Sharp.format = format;
  Sharp.versions = versions$2;
  Sharp.queue = queue;
};
```
This obviously leads to TypeError when trying to call e.g. sharp.cache(false). Could be an issue with Terser or other minifier as well.
The quick fix is to change the way it gets assigned (in PR).