### PR TITLE
Fix erroneous top/left clipping in composite #2571

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ vendor
 package-lock.json
 .idea
 .firebase
+/.vs

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -594,8 +594,13 @@ class PipelineWorker : public Napi::AsyncWorker {
           int top;
           if (composite->hasOffset) {
             // Composite image at given offsets
-            std::tie(left, top) = sharp::CalculateCrop(image.width(), image.height(),
-              compositeImage.width(), compositeImage.height(), composite->left, composite->top);
+            if (composite->tile) {
+              std::tie(left, top) = sharp::CalculateCrop(image.width(), image.height(),
+                compositeImage.width(), compositeImage.height(), composite->left, composite->top);
+            } else {
+              left = composite->left;
+              top = composite->top;
+            }
           } else {
             // Composite image with given gravity
             std::tie(left, top) = sharp::CalculateCrop(image.width(), image.height(),

--- a/test/unit/composite.js
+++ b/test/unit/composite.js
@@ -390,4 +390,20 @@ describe('composite', () => {
       }, /Expected valid gravity for gravity but received invalid of type string/);
     });
   });
+
+  it('Allow offset beyond bottom/right edge', async () => {
+    const red = { r: 255, g: 0, b: 0 };
+    const blue = { r: 0, g: 0, b: 255 };
+
+    const [r, g, b] = await sharp({ create: { width: 2, height: 2, channels: 4, background: red } })
+      .composite([{
+        input: { create: { width: 2, height: 2, channels: 4, background: blue } },
+        top: 1,
+        left: 1
+      }])
+      .raw()
+      .toBuffer();
+
+    assert.deepStrictEqual(red, { r, g, b });
+  });
 });


### PR DESCRIPTION
#2571 Fixes bug where certain input values for top/left parameters
in composite can conflict with clipping logic, resulting in
inaccurate alignment in output png. Adds logic to run check
which determines if clipping needs to be applied.
Issue #2571 