### PR TITLE
Update the instruction on mirror settings

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -130,7 +130,6 @@ Alibaba provide a mirror site based in China containing binaries for both sharp 
 To use this either set the following configuration:
 
 ```sh
-npm config set sharp_binary_host "https://npm.taobao.org/mirrors/sharp"
 npm config set sharp_libvips_binary_host "https://npm.taobao.org/mirrors/sharp-libvips"
 npm install sharp
 ```
@@ -138,9 +137,8 @@ npm install sharp
 or set the following environment variables:
 
 ```sh
-npm_config_sharp_binary_host="https://npm.taobao.org/mirrors/sharp" \
-  npm_config_sharp_libvips_binary_host="https://npm.taobao.org/mirrors/sharp-libvips" \
-  npm install sharp
+npm_config_sharp_libvips_binary_host="https://npm.taobao.org/mirrors/sharp-libvips" \
+npm install sharp
 ```
 
 ## FreeBSD


### PR DESCRIPTION
According to the [source](https://github.com/lovell/sharp/blob/master/install/libvips.js#L26-L27), using `npm_config_sharp_libvips_binary_host` is enough to install the binary from mirror host.
In fact, it doesn't work if `sharp_binary_host` is set to `"https://npm.taobao.org/mirrors/sharp"` (should be `"https://npm.taobao.org/mirrors/sharp-libvips/v8.10.0/"`).