### PR TITLE
Tests: fix unit test description

### DIFF
--- a/test/unit/extractChannel.js
+++ b/test/unit/extractChannel.js
@@ -107,7 +107,7 @@ describe('Image channel extraction', function () {
     });
   });
 
-  it('Non-existant channel', function (done) {
+  it('Non-existent channel', function (done) {
     sharp(fixtures.inputPng)
       .extractChannel(1)
       .toBuffer(function (err) {


### PR DESCRIPTION
The description of the last unit test in `test/unit/extractChannel` is misspelled.