### PR TITLE
flatten jsdoc: object instead of string

### DIFF
--- a/docs/api-operation.md
+++ b/docs/api-operation.md
@@ -180,7 +180,7 @@ Merge alpha transparency channel, if any, with a background, then remove the alp
 
 ```javascript
 await sharp(rgbaInput)
-  .flatten('#F0A703')
+  .flatten({background: '#F0A703' })
   .toBuffer();
 ```
 

--- a/lib/operation.js
+++ b/lib/operation.js
@@ -272,7 +272,7 @@ function blur (sigma) {
  *
  * @example
  * await sharp(rgbaInput)
- *   .flatten('#F0A703')
+ *   .flatten({background: '#F0A703' })
  *   .toBuffer();
  *
  * @param {Object} [options]


### PR DESCRIPTION
I just noticed that the docs show `flatten` with a string.

`flatten` expects an options object with background property,  passing a color string always results in black background.