### PR TITLE
install: fix proxy authentication when password contains special character

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -25,7 +25,7 @@ module.exports = function () {
       ? tunnelAgent.httpsOverHttps
       : tunnelAgent.httpsOverHttp;
     const proxyAuth = proxy.username && proxy.password
-      ? `${proxy.username}:${proxy.password}`
+      ? `${decodeURIComponent(proxy.username)}:${decodeURIComponent(proxy.password)}`
       : null;
     return tunnel({
       proxy: {

--- a/test/unit/agent.js
+++ b/test/unit/agent.js
@@ -19,6 +19,17 @@ describe('HTTP agent', function () {
     assert.strictEqual(443, proxy.defaultPort);
   });
 
+  it('HTTPS proxy with auth from HTTPS_PROXY using credentials containing special characters', function () {
+    process.env.HTTPS_PROXY = 'https://user,:pass=@secure:123';
+    const proxy = agent();
+    delete process.env.HTTPS_PROXY;
+    assert.strictEqual('object', typeof proxy);
+    assert.strictEqual('secure', proxy.options.proxy.host);
+    assert.strictEqual(123, proxy.options.proxy.port);
+    assert.strictEqual('user,:pass=', proxy.options.proxy.proxyAuth);
+    assert.strictEqual(443, proxy.defaultPort);
+  });
+
   it('HTTP proxy without auth from npm_config_proxy', function () {
     process.env.npm_config_proxy = 'http://plaintext:456';
     const proxy = agent();


### PR DESCRIPTION
Hello,

When we install `sharp` module on a machine which is behind a proxy, we have an error  `ERR! sharp tunneling socket could not be established, statusCode=407` if the password contains special characters.

This problem is because the `agent()` function returns a `password`where special characters are encoded. 
To fix this problem, we just need  to decode password before to return it. 

Open to any suggestions of course.