### PR TITLE
Fix minor grammatical error in Installation docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -123,7 +123,7 @@ See the Chinese mirror below for a further example.
 
 ## Chinese mirror
 
-Alibaba provides a mirror site based in China containing binaries for both sharp and libvips.
+A mirror site based in China, provided by Alibaba, contains binaries for both sharp and libvips.
 
 To use this either set the following configuration:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -123,7 +123,7 @@ See the Chinese mirror below for a further example.
 
 ## Chinese mirror
 
-Alibaba provide a mirror site based in China containing binaries for both sharp and libvips.
+Alibaba provides a mirror site based in China containing binaries for both sharp and libvips.
 
 To use this either set the following configuration:
 


### PR DESCRIPTION
Changed `Alibaba provide a mirror site` to `Alibaba provides a mirror site`.