### PR TITLE
Allow cross platform installation by custom libc flag

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -54,6 +54,8 @@ When using npm v6 or earlier, the `npm install --unsafe-perm` flag must be used 
 
 When using npm v7, the user running `npm install` must own the directory it is run in.
 
+When installing cross platform prebuilts on linux hosts an installation can be forced by `--sharp-install-force` flag or by setting `SHARP_INSTALL_FORCE` env variable.
+
 The `npm install --ignore-scripts=false` flag must be used when `npm` has been configured to ignore installation scripts.
 
 Check the output of running `npm install --verbose sharp` for useful error messages.


### PR DESCRIPTION
I would like to create cross platform bundles including sharp prebuilds, e.g. installing sharp for darwin-x64 on a linux-arm64 machine. For that reason the libc checks needs to be disabled - or the installation needs to be forced.

I am aware that this flag is kind of I-know-what-I-am-doing - I am open for discussions

And again: Thank you for this great library :-)