### PR TITLE
Add support for different bit depths with raw input and output

### DIFF
--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -253,6 +253,7 @@ const Sharp = function (input, options) {
     heifCompression: 'av1',
     heifSpeed: 5,
     heifChromaSubsampling: '4:4:4',
+    rawDepth: 'uchar',
     tileSize: 256,
     tileOverlap: 0,
     tileContainer: 'fs',

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -92,8 +92,9 @@ const debuglog = util.debuglog('sharp');
  *  }
  * }).toFile('noise.png');
  *
- * @param {(Buffer|Uint8Array|Uint8ClampedArray|string)} [input] - if present, can be
- *  a Buffer / Uint8Array / Uint8ClampedArray containing JPEG, PNG, WebP, AVIF, GIF, SVG, TIFF or raw pixel image data, or
+ * @param {(Buffer|Uint8Array|Uint8ClampedArray|Int8Array|Uint16Array|Int16Array|Uint32Array|Int32Array|Float32Array|Float64Array|string)} [input] - if present, can be
+ *  a Buffer / Uint8Array / Uint8ClampedArray containing JPEG, PNG, WebP, AVIF, GIF, SVG or TIFF image data, or
+ *  a Uint8Array / Uint8ClampedArray / Int8Array / Uint16Array / Int16Array / Uint32Array / Int32Array / Float32Array / Float64Array containing raw pixel image data, or
  *  a String containing the filesystem path to an JPEG, PNG, WebP, AVIF, GIF, SVG or TIFF image file.
  *  JPEG, PNG, WebP, AVIF, GIF, SVG, TIFF or raw pixel image data can be streamed into the object when not present.
  * @param {Object} [options] - if present, is an Object with optional attributes.

--- a/lib/input.js
+++ b/lib/input.js
@@ -34,8 +34,7 @@ function _createInputDescriptor (input, inputOptions, containerOptions) {
       throw Error('Input Buffer is empty');
     }
     inputDescriptor.buffer = input;
-  } else if (is.uint8Array(input)) {
-    // Uint8Array or Uint8ClampedArray
+  } else if (is.typedArray(input)) {
     if (input.length === 0) {
       throw Error('Input Bit Array is empty');
     }
@@ -104,6 +103,37 @@ function _createInputDescriptor (input, inputOptions, containerOptions) {
         inputDescriptor.rawHeight = inputOptions.raw.height;
         inputDescriptor.rawChannels = inputOptions.raw.channels;
         inputDescriptor.rawPremultiplied = !!inputOptions.raw.premultiplied;
+
+        switch (input.constructor) {
+          case Uint8Array:
+          case Uint8ClampedArray:
+            inputDescriptor.rawDepth = 'uchar';
+            break;
+          case Int8Array:
+            inputDescriptor.rawDepth = 'char';
+            break;
+          case Uint16Array:
+            inputDescriptor.rawDepth = 'ushort';
+            break;
+          case Int16Array:
+            inputDescriptor.rawDepth = 'short';
+            break;
+          case Uint32Array:
+            inputDescriptor.rawDepth = 'uint';
+            break;
+          case Int32Array:
+            inputDescriptor.rawDepth = 'int';
+            break;
+          case Float32Array:
+            inputDescriptor.rawDepth = 'float';
+            break;
+          case Float64Array:
+            inputDescriptor.rawDepth = 'double';
+            break;
+          default:
+            inputDescriptor.rawDepth = 'uchar';
+            break;
+        }
       } else {
         throw new Error('Expected width, height and channels for raw pixel input');
       }

--- a/lib/is.js
+++ b/lib/is.js
@@ -49,12 +49,26 @@ const buffer = function (val) {
 };
 
 /**
- * Is this value a Uint8Array or Uint8ClampedArray object?
+ * Is this value a typed array object?. E.g. Uint8Array or Uint8ClampedArray?
  * @private
  */
-const uint8Array = function (val) {
-  // allow both since Uint8ClampedArray simply clamps the values between 0-255
-  return val instanceof Uint8Array || val instanceof Uint8ClampedArray;
+const typedArray = function (val) {
+  if (defined(val)) {
+    switch (val.constructor) {
+      case Uint8Array:
+      case Uint8ClampedArray:
+      case Int8Array:
+      case Uint16Array:
+      case Int16Array:
+      case Uint32Array:
+      case Int32Array:
+      case Float32Array:
+      case Float64Array:
+        return true;
+    }
+  }
+
+  return false;
 };
 
 /**
@@ -119,7 +133,7 @@ module.exports = {
   fn: fn,
   bool: bool,
   buffer: buffer,
-  uint8Array: uint8Array,
+  typedArray: typedArray,
   string: string,
   number: number,
   integer: integer,

--- a/lib/output.js
+++ b/lib/output.js
@@ -748,7 +748,16 @@ function heif (options) {
  *
  * @returns {Sharp}
  */
-function raw () {
+function raw (options) {
+  if (is.object(options)) {
+    if (is.defined(options.depth)) {
+      if (is.string(options.depth) && is.inArray(options.depth, ['char', 'uchar', 'short', 'ushort', 'int', 'uint', 'float', 'complex', 'double', 'dpcomplex'])) {
+        this.options.rawDepth = options.depth;
+      } else {
+        throw is.invalidParameterError('depth', 'one of: char, uchar, short, ushort, int, uint, float, complex, double, dpcomplex', options.depth);
+      }
+    }
+  }
   return this._updateFormatOut('raw');
 }
 

--- a/src/common.cc
+++ b/src/common.cc
@@ -92,6 +92,9 @@ namespace sharp {
     }
     // Raw pixel input
     if (HasAttr(input, "rawChannels")) {
+      descriptor->rawDepth = static_cast<VipsBandFormat>(
+        vips_enum_from_nick(nullptr, VIPS_TYPE_BAND_FORMAT,
+        AttrAsStr(input, "rawDepth").data()));
       descriptor->rawChannels = AttrAsUint32(input, "rawChannels");
       descriptor->rawWidth = AttrAsUint32(input, "rawWidth");
       descriptor->rawHeight = AttrAsUint32(input, "rawHeight");
@@ -297,7 +300,7 @@ namespace sharp {
       if (descriptor->rawChannels > 0) {
         // Raw, uncompressed pixel data
         image = VImage::new_from_memory(descriptor->buffer, descriptor->bufferLength,
-          descriptor->rawWidth, descriptor->rawHeight, descriptor->rawChannels, VIPS_FORMAT_UCHAR);
+          descriptor->rawWidth, descriptor->rawHeight, descriptor->rawChannels, descriptor->rawDepth);
         if (descriptor->rawChannels < 3) {
           image.get_image()->Type = VIPS_INTERPRETATION_B_W;
         } else {

--- a/src/common.h
+++ b/src/common.h
@@ -54,6 +54,7 @@ namespace sharp {
     size_t bufferLength;
     bool isBuffer;
     double density;
+    VipsBandFormat rawDepth;
     int rawChannels;
     int rawWidth;
     int rawHeight;
@@ -78,6 +79,7 @@ namespace sharp {
       bufferLength(0),
       isBuffer(FALSE),
       density(72.0),
+      rawDepth(VIPS_FORMAT_UCHAR),
       rawChannels(0),
       rawWidth(0),
       rawHeight(0),

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -168,6 +168,7 @@ struct PipelineBaton {
   int heifSpeed;
   std::string heifChromaSubsampling;
   bool heifLossless;
+  VipsBandFormat rawDepth;
   std::string err;
   bool withMetadata;
   int withMetadataOrientation;
@@ -296,6 +297,7 @@ struct PipelineBaton {
     heifSpeed(5),
     heifChromaSubsampling("4:4:4"),
     heifLossless(false),
+    rawDepth(VIPS_FORMAT_UCHAR),
     withMetadata(false),
     withMetadataOrientation(-1),
     withMetadataDensity(0.0),


### PR DESCRIPTION
Fixes https://github.com/lovell/sharp/issues/1454 and fixes https://github.com/lovell/sharp/issues/1289. I've mostly added just the logic to support input or output raw data in different bit depths for now. If you like it, I'll also adjust the documentation accordingly and ensure test coverage of course.

***

### Raw input example
```javascript
const input = new Uint16Array( 48 );
for ( let i = 1; i < 48; i += 3 ) {
  input[ i ] = 0xffff;
}
sharp( input, {
  raw: {
    width: 4,
    height: 4,
    channels: 3,
  },
} ).toFile( "16bpc.png" );
```
This generates a green 4x4 .png file with 16 bits per pixel per color.

***

### Raw output example
```javascript
sharp( "16bpc.png" )
  .toColourspace( "rgb16" )
  .raw( {
    depth: "ushort",
  } )
  .toBuffer( ( error, data, {
    width,
    height,
    channels,
    size,
  } ) => {
    console.log( size / width / height / channels * 8 );
    console.log( new Uint16Array( data.buffer ) );
  } );
```
This takes the above .png file and reads the raw pixels from it as an `Uint16Array`. Note that the raw output still defaults to 8-bit results, so you have to explicitly use `{ depth: "ushort" }`. Also, `.toColourspace( "rgb16" )` is needed to prevent downsampling earlier on in the pipeline with 
https://github.com/lovell/sharp/blob/61640fb5c7ed834c264756e224ec81079f8baec2/src/pipeline.cc#L711
Maybe you have a suggestion on how to do this automatically?

***

Please let me know your thoughts on this PR, I'd happy to work some more on it to get it merged.