### PR TITLE
Allow using speed 9 for AVIF/HEIC encoding

### DIFF
--- a/docs/api-output.md
+++ b/docs/api-output.md
@@ -427,7 +427,7 @@ AVIF image sequences are not supported.
 
     *   `options.quality` **[number][9]** quality, integer 1-100 (optional, default `50`)
     *   `options.lossless` **[boolean][7]** use lossless compression (optional, default `false`)
-    *   `options.speed` **[number][9]** CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest) (optional, default `5`)
+    *   `options.speed` **[number][9]** CPU effort vs file size, 0 (slowest/smallest) to 9 (fastest/largest) (optional, default `5`)
     *   `options.chromaSubsampling` **[string][2]** set to '4:2:0' to use chroma subsampling (optional, default `'4:4:4'`)
 
 <!---->
@@ -454,7 +454,7 @@ globally-installed libvips compiled with support for libheif, libde265 and x265.
     *   `options.quality` **[number][9]** quality, integer 1-100 (optional, default `50`)
     *   `options.compression` **[string][2]** compression format: av1, hevc (optional, default `'av1'`)
     *   `options.lossless` **[boolean][7]** use lossless compression (optional, default `false`)
-    *   `options.speed` **[number][9]** CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest) (optional, default `5`)
+    *   `options.speed` **[number][9]** CPU effort vs file size, 0 (slowest/smallest) to 9 (fastest/largest) (optional, default `5`)
     *   `options.chromaSubsampling` **[string][2]** set to '4:2:0' to use chroma subsampling (optional, default `'4:4:4'`)
 
 <!---->

--- a/lib/output.js
+++ b/lib/output.js
@@ -746,7 +746,7 @@ function tiff (options) {
  * @param {Object} [options] - output options
  * @param {number} [options.quality=50] - quality, integer 1-100
  * @param {boolean} [options.lossless=false] - use lossless compression
- * @param {number} [options.speed=5] - CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest)
+ * @param {number} [options.speed=5] - CPU effort vs file size, 0 (slowest/smallest) to 9 (fastest/largest)
  * @param {string} [options.chromaSubsampling='4:4:4'] - set to '4:2:0' to use chroma subsampling
  * @returns {Sharp}
  * @throws {Error} Invalid options
@@ -767,7 +767,7 @@ function avif (options) {
  * @param {number} [options.quality=50] - quality, integer 1-100
  * @param {string} [options.compression='av1'] - compression format: av1, hevc
  * @param {boolean} [options.lossless=false] - use lossless compression
- * @param {number} [options.speed=5] - CPU effort vs file size, 0 (slowest/smallest) to 8 (fastest/largest)
+ * @param {number} [options.speed=5] - CPU effort vs file size, 0 (slowest/smallest) to 9 (fastest/largest)
  * @param {string} [options.chromaSubsampling='4:4:4'] - set to '4:2:0' to use chroma subsampling
  * @returns {Sharp}
  * @throws {Error} Invalid options
@@ -796,10 +796,10 @@ function heif (options) {
       }
     }
     if (is.defined(options.speed)) {
-      if (is.integer(options.speed) && is.inRange(options.speed, 0, 8)) {
+      if (is.integer(options.speed) && is.inRange(options.speed, 0, 9)) {
         this.options.heifSpeed = options.speed;
       } else {
-        throw is.invalidParameterError('speed', 'integer between 0 and 8', options.speed);
+        throw is.invalidParameterError('speed', 'integer between 0 and 9', options.speed);
       }
     }
     if (is.defined(options.chromaSubsampling)) {

--- a/test/unit/heif.js
+++ b/test/unit/heif.js
@@ -57,7 +57,7 @@ describe('HEIF', () => {
   });
   it('out of range speed should throw an error', () => {
     assert.throws(() => {
-      sharp().heif({ speed: 9 });
+      sharp().heif({ speed: 10 });
     });
   });
   it('invalid speed should throw an error', () => {


### PR DESCRIPTION
Fixes #2861

Do we need to check for specific versions of libvips or libaom, or is this fine as it stands?