### PR TITLE
Allow alternate tif format for tiff for #2775

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -13,6 +13,7 @@ const formats = new Map([
   ['png', 'png'],
   ['raw', 'raw'],
   ['tiff', 'tiff'],
+  ['tif', 'tiff'],
   ['webp', 'webp'],
   ['gif', 'gif'],
   ['jp2', 'jp2'],

--- a/test/unit/io.js
+++ b/test/unit/io.js
@@ -298,6 +298,21 @@ describe('Input/output', function () {
       });
   });
 
+  it('Support output to tif format', function (done) {
+    sharp(fixtures.inputTiff)
+      .resize(320, 240)
+      .toFormat('tif')
+      .toBuffer(function (err, data, info) {
+        if (err) throw err;
+        assert.strictEqual(true, data.length > 0);
+        assert.strictEqual(data.length, info.size);
+        assert.strictEqual('tiff', info.format);
+        assert.strictEqual(320, info.width);
+        assert.strictEqual(240, info.height);
+        done();
+      });
+  });
+
   it('Fail when output File is input File', function (done) {
     sharp(fixtures.inputJpg).toFile(fixtures.inputJpg, function (err) {
       assert(err instanceof Error);


### PR DESCRIPTION
Should solve #2775 by adding an alternative `tif` format for `tiff`.

Added a unit test which calls `toFormat('tif')` and asserts format is `tiff`.