### PR TITLE
check `sharp` module already loaded

### DIFF
--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -19,6 +19,11 @@ try {
   help.push(
     '- Consult the installation documentation: https://sharp.pixelplumbing.com/install'
   );
+  // Check loaded
+  const loaded = Object.keys(require.cache).find((i) => /[\\/]build[\\/]Release[\\/]sharp(.*)\.node$/.test(i));
+  if (loaded) {
+    help.push(`- Module already loaded in: ${loaded}`);
+  }
   console.error(help.join('\n'));
   process.exit(1);
 }


### PR DESCRIPTION
Hi!
More readable error if `sharp` already loaded in peer deps.

e.g.:

test.js
```js
const favicons = require('favicons'); 
const sharp = require('sharp');
```

output:
```
node ./test.js

Something went wrong installing the "sharp" module

The specified procedure could not be found.
\\?\/home/sharp-something-wrong/node_modules/sharp/build/Release/sharp-win32-x64.node

Possible solutions:
- Install with the --verbose flag and look for errors: "npm install --ignore-scripts=false --verbose sharp"
- Install for the current runtime: "npm install --platform=win32 --arch=x64 sharp"
- Consult the installation documentation: https://sharp.pixelplumbing.com/install
- Module already loaded in: /home/sharp-something-wrong/node_modules/favicons/node_modules/sharp/build/Release/sharp.node
```

npm ls sharp
```
+-- favicons-webpack-plugin@5.0.2
| `-- favicons@6.2.2
|   `-- sharp@0.28.3
`-- sharp@0.29.1
```