### PR TITLE
Impute TIFF xres/yres from withMetadata({density})

### DIFF
--- a/docs/api-output.md
+++ b/docs/api-output.md
@@ -125,7 +125,7 @@ sRGB colour space and strip all metadata, including the removal of any ICC profi
     *   `options.orientation` **[number][9]?** value between 1 and 8, used to update the EXIF `Orientation` tag.
     *   `options.icc` **[string][2]?** filesystem path to output ICC profile, defaults to sRGB.
     *   `options.exif` **[Object][6]<[Object][6]>** Object keyed by IFD0, IFD1 etc. of key/value string pairs to write as EXIF data. (optional, default `{}`)
-    *   `options.density` **[number][9]?** Number of pixels per inch (DPI).
+    *   `options.density` **[number][9]?** Number of pixels per inch (DPI). (If the output format is TIFF, this value will only apply if the TIFF options _do not_ explicitly specify a non-default `xres` and/or `yres`.)
 
 ### Examples
 

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -1492,6 +1492,9 @@ Napi::Value pipeline(const Napi::CallbackInfo& info) {
   baton->tiffTileHeight = sharp::AttrAsUint32(options, "tiffTileHeight");
   baton->tiffXres = sharp::AttrAsDouble(options, "tiffXres");
   baton->tiffYres = sharp::AttrAsDouble(options, "tiffYres");
+  if (baton->tiffXres == 1.0 && baton->tiffYres == 1.0 && baton->withMetadataDensity > 0) {
+    baton->tiffXres = baton->tiffYres = baton->withMetadataDensity / 25.4;
+  }
   // tiff compression options
   baton->tiffCompression = static_cast<VipsForeignTiffCompression>(
   vips_enum_from_nick(nullptr, VIPS_TYPE_FOREIGN_TIFF_COMPRESSION,

--- a/test/unit/tiff.js
+++ b/test/unit/tiff.js
@@ -188,6 +188,26 @@ describe('TIFF', function () {
       )
   );
 
+  it('TIFF imputes xres and yres from withMetadataDensity if not explicitly provided', async () => {
+    const data = await sharp(fixtures.inputTiff)
+      .resize(8, 8)
+      .tiff()
+      .withMetadata({ density: 600 })
+      .toBuffer();
+    const { density } = await sharp(data).metadata();
+    assert.strictEqual(600, density);
+  });
+
+  it('TIFF uses xres and yres over withMetadataDensity if explicitly provided', async () => {
+    const data = await sharp(fixtures.inputTiff)
+      .resize(8, 8)
+      .tiff({ xres: 1000, yres: 1000 })
+      .withMetadata({ density: 600 })
+      .toBuffer();
+    const { density } = await sharp(data).metadata();
+    assert.strictEqual(25400, density);
+  });
+
   it('TIFF invalid xres value should throw an error', function () {
     assert.throws(function () {
       sharp().tiff({ xres: '1000.0' });


### PR DESCRIPTION
Closes #2941 

This PR uses the `density` value passed to `withMetadata()` as a fallback if the output format is TIFF and netter `xres` nor `yres` is provided in the TIFF options. I've also updated the API documentation with to include a short explanation of this behavior.