### PR TITLE
Addition of pngBitdepth option to png

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -393,6 +393,13 @@ function png (options) {
         throw is.invalidParameterError('compressionLevel', 'integer between 0 and 9', options.compressionLevel);
       }
     }
+    if (is.defined(options.pngBitdepth)) {
+      if ([8, 16].includes(options.pngBitdepth)) {
+        this.options.pngBitdepth = options.pngBitdepth;
+      } else {
+        throw is.invalidParameterError('pngBitdepth', 'integer of 8 or 16', options.png);
+      }
+    }
     if (is.defined(options.adaptiveFiltering)) {
       this._setBooleanOption('pngAdaptiveFiltering', options.adaptiveFiltering);
     }

--- a/test/unit/resize-contain.js
+++ b/test/unit/resize-contain.js
@@ -116,6 +116,27 @@ describe('Resize fit=contain', function () {
       });
   });
 
+  it("16-bit PNG to and from buffer should retain 16-bit stats", async function () {
+    const img = sharp(fixtures.inputPng16BitGreyAlpha);
+
+    const { newImg } = await new Promise((resolve, reject) => {
+      img
+        .png({ pngBitdepth: 16 })
+        .toColourspace('grey16')
+        .toBuffer(async function (err, data, info) {
+          if (err) throw err;
+
+          const imgFromBuffer = sharp(data);
+          resolve({
+            newMeta: await imgFromBuffer.metadata(),
+            newImg: imgFromBuffer,
+          });
+        });
+    });
+
+    assert.deepStrictEqual((await newImg.stats()).channels[1], (await img.stats()).channels[1]);
+  });
+
   it('TIFF in LAB colourspace onto RGBA background', function (done) {
     sharp(fixtures.inputTiffCielab)
       .resize(64, 128, {


### PR DESCRIPTION

The suggested fix for issue #2934. Note that this causes warning of type:

> (process:25977): GLib-GObject-WARNING **: 22:25:02.057: value "16" of type 'gint' is invalid or out of range for property 'bitdepth' of type 'gint'