### PR TITLE
Remove double entry for mbklein

### DIFF
--- a/docs/humans.txt
+++ b/docs/humans.txt
@@ -227,6 +227,3 @@ GitHub: https://github.com/Zaruike
 
 Name: Erlend F
 GitHub: https://github.com/erf
-
-Name: Michael B. Klein
-GitHub: https://github.com/mbklein


### PR DESCRIPTION
My name was already in `humans.txt` from the merge of #1483.