### PR TITLE
Heroku docs: Add VIPS buildpack dependencies

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -199,6 +199,16 @@ Set
 [NODE_MODULES_CACHE](https://devcenter.heroku.com/articles/nodejs-support#cache-behavior)
 to `false` when using the `yarn` package manager.
 
+If you are using https://github.com/brandoncc/heroku-buildpack-vips to install VIPS, you may also need the following packages:
+
+- libglib2.0-0
+- libglib2.0-dev
+- libpoppler-glib8
+- libpoppler-glib-dev
+- libheif-dev
+- libfftw3-dev
+- libwebp-dev
+
 ## AWS Lambda
 
 The `node_modules` directory of the


### PR DESCRIPTION
I used https://github.com/brandoncc/heroku-buildpack-vips to install VIPS in my heroku app, and discovered that I needed to install some extra packages to get it working. I opened up a PR on that repo, but then realized that it might be more relevant here.

There's some related documentation here: https://gist.github.com/bigtiger/be41fffcd103d7e98c5fe4fdff0af3f9