### PR TITLE
Windows: make invalid param errors recoverable by default

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -39,6 +39,7 @@
               'VCCLCompilerTool': {
                 'ExceptionHandling': 1,
                 'Optimization': 1,
+                'RuntimeLibrary': '2', # /MD
                 'WholeProgramOptimization': 'true'
               },
               'VCLibrarianTool': {
@@ -205,6 +206,7 @@
               'VCCLCompilerTool': {
                 'ExceptionHandling': 1,
                 'Optimization': 1,
+                'RuntimeLibrary': '2', # /MD
                 'WholeProgramOptimization': 'true'
               },
               'VCLibrarianTool': {

--- a/test/unit/io.js
+++ b/test/unit/io.js
@@ -797,6 +797,19 @@ describe('Input/output', function () {
     });
   });
 
+  it('Fails when writing to missing directory', async () => {
+    const create = {
+      width: 8,
+      height: 8,
+      channels: 3,
+      background: { r: 0, g: 0, b: 0 }
+    };
+    await assert.rejects(
+      () => sharp({ create }).toFile('does-not-exist/out.jpg'),
+      /unable to open for write/
+    );
+  });
+
   describe('create new image', function () {
     it('RGB', function (done) {
       const create = {


### PR DESCRIPTION
Context: #2999 and https://github.com/libvips/libvips/pull/2571.