### PR TITLE
Ensure operations without multi-page support reject rather than silently fail

### DIFF
--- a/test/unit/affine.js
+++ b/test/unit/affine.js
@@ -155,6 +155,15 @@ describe('Affine transform', () => {
         fixtures.assertSimilar(fixtures.expected('affine-background-all-offsets-expected.jpg'), data, done);
       });
   });
+
+  it('Animated image rejects', () =>
+    assert.rejects(() => sharp(fixtures.inputGifAnimated, { animated: true })
+      .affine([1, 1, 1, 1])
+      .toBuffer(),
+    /Affine is not supported for multi-page images/
+    )
+  );
+
   describe('Interpolations', () => {
     const input = fixtures.inputJpg320x240;
     const inputWidth = 320;

--- a/test/unit/resize-cover.js
+++ b/test/unit/resize-cover.js
@@ -347,6 +347,18 @@ describe('Resize fit=cover', function () {
           fixtures.assertSimilar(fixtures.expected('crop-strategy.png'), data, done);
         });
     });
+
+    it('Animated image rejects', () =>
+      assert.rejects(() => sharp(fixtures.inputGifAnimated, { animated: true })
+        .resize({
+          width: 100,
+          height: 8,
+          position: sharp.strategy.entropy
+        })
+        .toBuffer(),
+      /Resize strategy is not supported for multi-page images/
+      )
+    );
   });
 
   describe('Attention strategy', function () {
@@ -403,5 +415,17 @@ describe('Resize fit=cover', function () {
           fixtures.assertSimilar(fixtures.expected('crop-strategy.png'), data, done);
         });
     });
+
+    it('Animated image rejects', () =>
+      assert.rejects(() => sharp(fixtures.inputGifAnimated, { animated: true })
+        .resize({
+          width: 100,
+          height: 8,
+          position: sharp.strategy.attention
+        })
+        .toBuffer(),
+      /Resize strategy is not supported for multi-page images/
+      )
+    );
   });
 });

--- a/test/unit/rotate.js
+++ b/test/unit/rotate.js
@@ -272,6 +272,34 @@ describe('Rotation', function () {
     });
   });
 
+  it('Animated image rotate-then-extract rejects', () =>
+    assert.rejects(() => sharp(fixtures.inputGifAnimated, { animated: true })
+      .rotate(1)
+      .extract({
+        top: 1,
+        left: 1,
+        width: 10,
+        height: 10
+      })
+      .toBuffer(),
+    /Rotate is not supported for multi-page images/
+    )
+  );
+
+  it('Animated image extract-then-rotate rejects', () =>
+    assert.rejects(() => sharp(fixtures.inputGifAnimated, { animated: true })
+      .extract({
+        top: 1,
+        left: 1,
+        width: 10,
+        height: 10
+      })
+      .rotate(1)
+      .toBuffer(),
+    /Rotate is not supported for multi-page images/
+    )
+  );
+
   it('Flip - vertical', function (done) {
     sharp(fixtures.inputJpg)
       .resize(320)

--- a/test/unit/trim.js
+++ b/test/unit/trim.js
@@ -120,6 +120,14 @@ describe('Trim borders', function () {
       )
   );
 
+  it('Animated image rejects', () =>
+    assert.rejects(() => sharp(fixtures.inputGifAnimated, { animated: true })
+      .trim()
+      .toBuffer(),
+    /Trim is not supported for multi-page images/
+    )
+  );
+
   describe('Invalid thresholds', function () {
     [-1, 'fail', {}].forEach(function (threshold) {
       it(JSON.stringify(threshold), function () {


### PR DESCRIPTION
@kleisauke as we discussed in https://github.com/lovell/sharp/pull/2789#issuecomment-985072211

I didn't apply this to the `composite` operation as this should still work, plus can be used to watermark an animation via tiled composition.