### PR TITLE
Vulnerability: update simple-get package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "node-addon-api": "^4.2.0",
     "prebuild-install": "^7.0.0",
     "semver": "^7.3.5",
-    "simple-get": "^4.0.0",
+    "simple-get": "^4.0.1",
     "tar-fs": "^2.1.1",
     "tunnel-agent": "^0.6.0"
   },


### PR DESCRIPTION
According to [Snyk's vulnerability page](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGET-2361683), simply updating `simple-get` package version to fix this vulnerability.