### PR TITLE
Take page parameter into account when all frames are read

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -72,7 +72,9 @@ class PipelineWorker : public Napi::AsyncWorker {
       int nPages = baton->input->pages;
       if (nPages == -1) {
         // Resolve the number of pages if we need to render until the end of the document
-        nPages = image.get_typeof(VIPS_META_N_PAGES) != 0 ? image.get_int(VIPS_META_N_PAGES) : 1;
+        nPages = image.get_typeof(VIPS_META_N_PAGES) != 0
+          ? image.get_int(VIPS_META_N_PAGES) - baton->input->page
+          : 1;
       }
 
       // Get pre-resize page height

--- a/test/unit/webp.js
+++ b/test/unit/webp.js
@@ -217,4 +217,15 @@ describe('WebP', function () {
     assert.strictEqual(updated.height, 570 * 9);
     assert.strictEqual(updated.pageHeight, 570);
   });
+
+  it('should take page parameter into account when animated is set', async () => {
+    const updated = await sharp(fixtures.inputWebPAnimated, { animated: true, page: 2 })
+      .resize({ height: 570 })
+      .webp({ effort: 0 })
+      .toBuffer()
+      .then(data => sharp(data, { pages: -1 }).metadata());
+
+    assert.strictEqual(updated.height, 570 * 7);
+    assert.strictEqual(updated.pageHeight, 570);
+  });
 });


### PR DESCRIPTION
Otherwise, it could lead to funny results.

<details>
  <summary>Before / after examples</summary>

```bash
$ curl -LO https://storage.googleapis.com/downloads.webmproject.org/webp/images/dancing_banana2.lossless.webp
$ node -e "require('sharp')('dancing_banana2.lossless.webp', { pages: -1, page: 2 }).resize(128).toFile('x.gif')"
```
| Before | After |
| :---: |  :---: |
| ![before](https://user-images.githubusercontent.com/12746591/151360287-b3b9934b-8608-4cd3-87e4-9a6870078b3c.gif) | ![after](https://user-images.githubusercontent.com/12746591/151360320-6eec28be-1f1c-4c3b-b6b1-2c206a3b2164.gif) |

</details>

A test case was added to prevent further regressions.