### PR TITLE
Ensure delays of the origin image is preserved

### DIFF
--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -327,7 +327,6 @@ struct PipelineBaton {
     ensureAlpha(-1.0),
     colourspaceInput(VIPS_INTERPRETATION_LAST),
     colourspace(VIPS_INTERPRETATION_LAST),
-    delay{-1},
     loop(-1),
     tileSize(256),
     tileOverlap(0),

--- a/test/unit/webp.js
+++ b/test/unit/webp.js
@@ -183,6 +183,15 @@ describe('WebP', function () {
     assert.deepStrictEqual(updated.delay, expectedDelay);
   });
 
+  it('should preserve delay between frames', async () => {
+    const updated = await sharp(fixtures.inputWebPAnimated, { pages: -1 })
+      .webp()
+      .toBuffer()
+      .then(data => sharp(data, { pages: -1 }).metadata());
+
+    assert.deepStrictEqual(updated.delay, [120, 120, 90, 120, 120, 90, 120, 90, 30]);
+  });
+
   it('should work with streams when only animated is set', function (done) {
     fs.createReadStream(fixtures.inputWebPAnimated)
       .pipe(sharp({ animated: true }))


### PR DESCRIPTION
By not initializing the delay vector, since we assume it's empty by default  in `SetAnimationProperties`.
https://github.com/lovell/sharp/blob/68823a5edb0c913fb230cd36c1ce22554e48f9ad/src/common.cc#L495-L503

A test case was added to prevent further regressions.

See: #3061.