### PR TITLE
Move `withoutReduction` logic to `ResolveShrink`

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -885,7 +885,7 @@ namespace sharp {
   }
 
   std::pair<double, double> ResolveShrink(int width, int height, int targetWidth, int targetHeight,
-    Canvas canvas, bool swap, bool withoutEnlargement) {
+    Canvas canvas, bool swap, bool withoutEnlargement, bool withoutReduction) {
     if (swap) {
       // Swap input width and height when requested.
       std::swap(width, height);
@@ -940,9 +940,14 @@ namespace sharp {
       }
     }
 
-    // We should not enlarge (oversample) the output image,
-    // if withoutEnlargement is specified.
-    if (withoutEnlargement) {
+    // We should not reduce or enlarge the output image, if
+    // withoutReduction or withoutEnlargement is specified.
+    if (withoutReduction) {
+      // Equivalent of VIPS_SIZE_UP
+      hshrink = std::min(1.0, hshrink);
+      vshrink = std::min(1.0, vshrink);
+    } else if (withoutEnlargement) {
+      // Equivalent of VIPS_SIZE_DOWN
       hshrink = std::max(1.0, hshrink);
       vshrink = std::max(1.0, vshrink);
     }

--- a/src/common.h
+++ b/src/common.h
@@ -345,7 +345,7 @@ namespace sharp {
     the required thumbnail width/height and canvas mode.
   */
   std::pair<double, double> ResolveShrink(int width, int height, int targetWidth, int targetHeight,
-    Canvas canvas, bool swap, bool withoutEnlargement);
+    Canvas canvas, bool swap, bool withoutEnlargement, bool withoutReduction);
 
 }  // namespace sharp
 

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -138,17 +138,6 @@ class PipelineWorker : public Napi::AsyncWorker {
         pageHeight = inputHeight;
       }
 
-      // If withoutReduction is specified,
-      // Override target width and height if less than respective value from input file
-       if (baton->withoutReduction) {
-          if (baton->width < inputWidth) {
-            baton->width = inputWidth;
-          }
-          if (baton->height < inputHeight) {
-            baton->height = inputHeight;
-          }
-      }
-
       // Scaling calculations
       double hshrink;
       double vshrink;
@@ -161,7 +150,7 @@ class PipelineWorker : public Napi::AsyncWorker {
       // Shrink to pageHeight, so we work for multi-page images
       std::tie(hshrink, vshrink) = sharp::ResolveShrink(
         inputWidth, pageHeight, targetResizeWidth, targetResizeHeight,
-        baton->canvas, swap, baton->withoutEnlargement);
+        baton->canvas, swap, baton->withoutEnlargement, baton->withoutReduction);
 
       // The jpeg preload shrink.
       int jpegShrinkOnLoad = 1;
@@ -286,7 +275,7 @@ class PipelineWorker : public Napi::AsyncWorker {
       // Shrink to pageHeight, so we work for multi-page images
       std::tie(hshrink, vshrink) = sharp::ResolveShrink(
         inputWidth, pageHeight, targetResizeWidth, targetResizeHeight,
-        baton->canvas, swap, baton->withoutEnlargement);
+        baton->canvas, swap, baton->withoutEnlargement, baton->withoutReduction);
 
       int targetHeight = static_cast<int>(std::rint(static_cast<double>(pageHeight) / vshrink));
       int targetPageHeight = targetHeight;

--- a/test/unit/resize.js
+++ b/test/unit/resize.js
@@ -368,7 +368,7 @@ describe('Resize dimensions', function () {
         assert.strictEqual(true, data.length > 0);
         assert.strictEqual('jpeg', info.format);
         assert.strictEqual(2800, info.width);
-        assert.strictEqual(2225, info.height);
+        assert.strictEqual(2286, info.height);
         done();
       });
   });
@@ -383,42 +383,8 @@ describe('Resize dimensions', function () {
         if (err) throw err;
         assert.strictEqual(true, data.length > 0);
         assert.strictEqual('jpeg', info.format);
-        assert.strictEqual(2725, info.width);
+        assert.strictEqual(2817, info.width);
         assert.strictEqual(2300, info.height);
-        done();
-      });
-  });
-
-  it('Do not crop when fit = cover and withoutReduction = true and width >= outputWidth, and height < outputHeight', function (done) {
-    sharp(fixtures.inputJpg)
-      .resize({
-        width: 3000,
-        height: 1000,
-        withoutReduction: true
-      })
-      .toBuffer(function (err, data, info) {
-        if (err) throw err;
-        assert.strictEqual(true, data.length > 0);
-        assert.strictEqual('jpeg', info.format);
-        assert.strictEqual(3000, info.width);
-        assert.strictEqual(2225, info.height);
-        done();
-      });
-  });
-
-  it('Do not crop when fit = cover and withoutReduction = true and width < outputWidth, and height >= outputHeight', function (done) {
-    sharp(fixtures.inputJpg)
-      .resize({
-        width: 1500,
-        height: 2226,
-        withoutReduction: true
-      })
-      .toBuffer(function (err, data, info) {
-        if (err) throw err;
-        assert.strictEqual(true, data.length > 0);
-        assert.strictEqual('jpeg', info.format);
-        assert.strictEqual(2725, info.width);
-        assert.strictEqual(2226, info.height);
         done();
       });
   });


### PR DESCRIPTION
Ensures that it does not interfere with cropping/embedding.

See: #3067.