### PR TITLE
Windows: ensure C++ runtime is linked statically

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -39,7 +39,6 @@
               'VCCLCompilerTool': {
                 'ExceptionHandling': 1,
                 'Optimization': 1,
-                'RuntimeLibrary': '2', # /MD
                 'WholeProgramOptimization': 'true'
               },
               'VCLibrarianTool': {
@@ -206,7 +205,6 @@
               'VCCLCompilerTool': {
                 'ExceptionHandling': 1,
                 'Optimization': 1,
-                'RuntimeLibrary': '2', # /MD
                 'WholeProgramOptimization': 'true'
               },
               'VCLibrarianTool': {

--- a/src/sharp.cc
+++ b/src/sharp.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <napi.h>
-#include <cstdlib>
 #include <vips/vips8>
 
 #include "common.h"
@@ -21,14 +20,6 @@
 #include "pipeline.h"
 #include "utilities.h"
 #include "stats.h"
-
-#if defined(_MSC_VER) && _MSC_VER >= 1400  // MSVC 2005/8
-static void empty_invalid_parameter_handler(const wchar_t* expression,
-  const wchar_t* function, const wchar_t* file, unsigned int line,
-  uintptr_t reserved) {
-  // No-op.
-}
-#endif
 
 static void* sharp_vips_init(void*) {
   g_setenv("VIPS_MIN_STACK_SIZE", "2m", FALSE);
@@ -42,13 +33,6 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
 
   g_log_set_handler("VIPS", static_cast<GLogLevelFlags>(G_LOG_LEVEL_WARNING),
     static_cast<GLogFunc>(sharp::VipsWarningCallback), nullptr);
-
-  // Tell the CRT to not exit the application when an invalid parameter is
-  // passed. The main issue is that invalid FDs will trigger this behaviour.
-  // See: https://github.com/libvips/libvips/pull/2571.
-#if defined(_MSC_VER) && _MSC_VER >= 1400  // MSVC 2005/8
-  _set_invalid_parameter_handler(empty_invalid_parameter_handler);
-#endif
 
   // Methods available to JavaScript
   exports.Set("metadata", Napi::Function::New(env, metadata));


### PR DESCRIPTION
And remove the empty invalid parameter handler, which should
be present in the C layer instead.

This partially reverts commit 659cdabd8e8c284901a0ea17ccdcb13e17350a8e, the added test case in
that commit is still preserved.

See: #3086.