### PR TITLE
Add missing file name to 'Input file is missing' error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "Taneli Vatanen <taneli.vatanen@gmail.com>",
     "Joris Dugué <zaruike10@gmail.com>",
     "Chris Banks <christopher.bradley.banks@gmail.com>",
-    "Ompal Singh <ompal.hitm09@gmail.com>"
+    "Ompal Singh <ompal.hitm09@gmail.com>",
+    "Brodan <christopher.hranj@gmail.com"
   ],
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node install/can-compile && node-gyp rebuild && node install/dll-copy)",

--- a/src/common.cc
+++ b/src/common.cc
@@ -399,7 +399,7 @@ namespace sharp {
             throw vips::VError("Input file is missing, did you mean "
               "sharp(Buffer.from('" + descriptor->file.substr(0, 8) + "...')?");
           }
-          throw vips::VError("Input file is missing");
+          throw vips::VError("Input file is missing: " + descriptor->file);
         }
         if (imageType != ImageType::UNKNOWN) {
           try {

--- a/test/unit/io.js
+++ b/test/unit/io.js
@@ -457,7 +457,7 @@ describe('Input/output', function () {
       done();
     }).catch(function (err) {
       assert(err instanceof Error);
-      assert.strictEqual('Input file is missing', err.message);
+      assert.strictEqual('Input file is missing: does-not-exist', err.message);
       done();
     });
   });


### PR DESCRIPTION
Fixes #2360

This PR updates the error message 'Input file is missing' to include the file that is missing.