### PR TITLE
Feature to use locally downloaded libvips

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -135,8 +135,8 @@ set the `sharp_libvips_binary_host` npm config option
 or the `npm_config_sharp_libvips_binary_host` environment variable.
 
 To install the prebuilt libvips binaries from a directory on the local filesystem,
-set the `sharp_local_libvips_dir` npm config option
-or the `npm_config_sharp_local_libvips_dir` environment variable.
+set the `sharp_libvips_local_prebuilds` npm config option
+or the `npm_config_sharp_libvips_local_prebuilds` environment variable.
 
 The version subpath and file name are appended to these.
 For example, if `sharp_libvips_binary_host` is set to `https://hostname/path`

--- a/docs/install.md
+++ b/docs/install.md
@@ -118,6 +118,8 @@ Building from source requires:
 
 This is an advanced approach that most people will not require.
 
+### Prebuilt sharp binaries
+
 To install the prebuilt sharp binaries from a custom URL,
 set the `sharp_binary_host` npm config option
 or the `npm_config_sharp_binary_host` environment variable.
@@ -126,9 +128,15 @@ To install the prebuilt sharp binaries from a directory on the local filesystem,
 set the `sharp_local_prebuilds` npm config option
 or the `npm_config_sharp_local_prebuilds` environment variable.
 
+### Prebuilt libvips binaries
+
 To install the prebuilt libvips binaries from a custom URL,
 set the `sharp_libvips_binary_host` npm config option
 or the `npm_config_sharp_libvips_binary_host` environment variable.
+
+To install the prebuilt libvips binaries from a directory on the local filesystem,
+set the `sharp_local_libvips_dir` npm config option
+or the `npm_config_sharp_local_libvips_dir` environment variable.
 
 The version subpath and file name are appended to these.
 For example, if `sharp_libvips_binary_host` is set to `https://hostname/path`

--- a/install/libvips.js
+++ b/install/libvips.js
@@ -35,7 +35,7 @@ const hasSharpPrebuild = [
 ];
 
 const { minimumLibvipsVersion, minimumLibvipsVersionLabelled } = libvips;
-const localLibvipsDir = process.env.npm_config_sharp_local_libvips_dir || '';
+const localLibvipsDir = process.env.npm_config_sharp_libvips_local_prebuilds || '';
 const distHost = process.env.npm_config_sharp_libvips_binary_host || 'https://github.com/lovell/sharp-libvips/releases/download';
 const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || `${distHost}/v${minimumLibvipsVersionLabelled}/`;
 const installationForced = !!(process.env.npm_config_sharp_install_force || process.env.SHARP_INSTALL_FORCE);

--- a/install/libvips.js
+++ b/install/libvips.js
@@ -35,7 +35,7 @@ const hasSharpPrebuild = [
 ];
 
 const { minimumLibvipsVersion, minimumLibvipsVersionLabelled } = libvips;
-const localLibvipsDir = process.env.npm_config_sharp_libvips_binary_dir || '';
+const localLibvipsDir = process.env.npm_config_sharp_local_libvips_dir || '';
 const distHost = process.env.npm_config_sharp_libvips_binary_host || 'https://github.com/lovell/sharp-libvips/releases/download';
 const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || `${distHost}/v${minimumLibvipsVersionLabelled}/`;
 const installationForced = !!(process.env.npm_config_sharp_install_force || process.env.SHARP_INSTALL_FORCE);

--- a/install/libvips.js
+++ b/install/libvips.js
@@ -35,6 +35,7 @@ const hasSharpPrebuild = [
 ];
 
 const { minimumLibvipsVersion, minimumLibvipsVersionLabelled } = libvips;
+const localLibvipsDir = process.env.npm_config_sharp_libvips_binary_dir || '';
 const distHost = process.env.npm_config_sharp_libvips_binary_host || 'https://github.com/lovell/sharp-libvips/releases/download';
 const distBaseUrl = process.env.npm_config_sharp_dist_base_url || process.env.SHARP_DIST_BASE_URL || `${distHost}/v${minimumLibvipsVersionLabelled}/`;
 const installationForced = !!(process.env.npm_config_sharp_install_force || process.env.SHARP_INSTALL_FORCE);
@@ -156,6 +157,15 @@ try {
     if (fs.existsSync(tarPathCache)) {
       libvips.log(`Using cached ${tarPathCache}`);
       extractTarball(tarPathCache, platformAndArch);
+    } else if (localLibvipsDir) {
+      const tarPathLocal = path.join(path.resolve(localLibvipsDir), `v${minimumLibvipsVersionLabelled}`, tarFilename);
+      // If localLibvipsDir is given try to use binaries from local directory
+      if (fs.existsSync(tarPathLocal)) {
+        console.log(`Using local libvips from ${tarPathLocal}`);
+        extractTarball(tarPathLocal, platformAndArch);
+      } else {
+        fail(new Error(`Unable to use local libvips from ${tarPathLocal}`));
+      }
     } else {
       const url = distBaseUrl + tarFilename;
       libvips.log(`Downloading ${url}`);

--- a/install/libvips.js
+++ b/install/libvips.js
@@ -158,14 +158,10 @@ try {
       libvips.log(`Using cached ${tarPathCache}`);
       extractTarball(tarPathCache, platformAndArch);
     } else if (localLibvipsDir) {
-      const tarPathLocal = path.join(path.resolve(localLibvipsDir), `v${minimumLibvipsVersionLabelled}`, tarFilename);
       // If localLibvipsDir is given try to use binaries from local directory
-      if (fs.existsSync(tarPathLocal)) {
-        console.log(`Using local libvips from ${tarPathLocal}`);
-        extractTarball(tarPathLocal, platformAndArch);
-      } else {
-        fail(new Error(`Unable to use local libvips from ${tarPathLocal}`));
-      }
+      const tarPathLocal = path.join(path.resolve(localLibvipsDir), `v${minimumLibvipsVersionLabelled}`, tarFilename);
+      libvips.log(`Using local libvips from ${tarPathLocal}`);
+      extractTarball(tarPathLocal, platformAndArch);
     } else {
       const url = distBaseUrl + tarFilename;
       libvips.log(`Downloading ${url}`);

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "Joris Dugué <zaruike10@gmail.com>",
     "Chris Banks <christopher.bradley.banks@gmail.com>",
     "Ompal Singh <ompal.hitm09@gmail.com>",
-    "Brodan <christopher.hranj@gmail.com"
+    "Brodan <christopher.hranj@gmail.com",
+    "Ankur Parihar <ankur.github@gmail.com> (https://ankurparihar.github.io)"
   ],
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node install/can-compile && node-gyp rebuild && node install/dll-copy)",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "Chris Banks <christopher.bradley.banks@gmail.com>",
     "Ompal Singh <ompal.hitm09@gmail.com>",
     "Brodan <christopher.hranj@gmail.com",
-    "Ankur Parihar <ankur.github@gmail.com> (https://ankurparihar.github.io)"
+    "Ankur Parihar <ankur.github@gmail.com>"
   ],
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node install/can-compile && node-gyp rebuild && node install/dll-copy)",


### PR DESCRIPTION
Changes include

- Feature to install the prebuilt libvips binaries from a directory on the local filesystem
- Installation doc update
  - Separate instructions for prebuilt sharp and libvips binaries to avoid confusion
  - Added instructions to install prebuilt libvips binaries from local filesystem directory


Closes https://github.com/lovell/sharp/issues/3188