### PR TITLE
Fix typo in api-output.md

### DIFF
--- a/docs/api-output.md
+++ b/docs/api-output.md
@@ -334,7 +334,7 @@ The first entry in the palette is reserved for transparency.
 // Convert PNG to GIF
 await sharp(pngBuffer)
   .gif()
-  .toBuffer());
+  .toBuffer();
 ```
 
 ```javascript

--- a/lib/output.js
+++ b/lib/output.js
@@ -516,7 +516,7 @@ function webp (options) {
  * // Convert PNG to GIF
  * await sharp(pngBuffer)
  *   .gif()
- *   .toBuffer());
+ *   .toBuffer();
  *
  * @example
  * // Convert animated WebP to animated GIF


### PR DESCRIPTION
Removed an extra `)` on code example for converting to `gif`