### PR TITLE
fix rotate-then-extract for EXIF orientation 2

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -95,16 +95,18 @@ class PipelineWorker : public Napi::AsyncWorker {
       if (baton->rotateBeforePreExtract) {
         if (rotation != VIPS_ANGLE_D0) {
           image = image.rot(rotation);
-          if (flip) {
-            image = image.flip(VIPS_DIRECTION_VERTICAL);
-            flip = FALSE;
-          }
-          if (flop) {
-            image = image.flip(VIPS_DIRECTION_HORIZONTAL);
-            flop = FALSE;
-          }
+        }
+        if (flip) {
+          image = image.flip(VIPS_DIRECTION_VERTICAL);
+        }
+        if (flop) {
+          image = image.flip(VIPS_DIRECTION_HORIZONTAL);
+        }
+        if (rotation != VIPS_ANGLE_D0 || flip || flop) {
           image = sharp::RemoveExifOrientation(image);
         }
+        flop = FALSE;
+        flip = FALSE;
         if (baton->rotationAngle != 0.0) {
           MultiPageUnsupported(nPages, "Rotate");
           std::vector<double> background;

--- a/test/unit/extract.js
+++ b/test/unit/extract.js
@@ -168,14 +168,51 @@ describe('Partial image extraction', function () {
       });
   });
 
-  it('Rotate with EXIF mirroring then extract', function (done) {
-    sharp(fixtures.inputJpgWithLandscapeExif7)
-      .rotate()
-      .extract({ left: 0, top: 208, width: 60, height: 40 })
-      .toBuffer(function (err, data) {
-        if (err) throw err;
-        fixtures.assertSimilar(fixtures.expected('rotate-mirror-extract.jpg'), data, done);
+  describe('Apply exif orientation and mirroring then extract', () => {
+    [
+      {
+        name: 'EXIF-1',
+        image: fixtures.inputJpgWithLandscapeExif1
+      },
+      {
+        name: 'EXIF-2',
+        image: fixtures.inputJpgWithLandscapeExif2
+      },
+      {
+        name: 'EXIF-3',
+        image: fixtures.inputJpgWithLandscapeExif3
+      },
+      {
+        name: 'EXIF-4',
+        image: fixtures.inputJpgWithLandscapeExif4
+      },
+      {
+        name: 'EXIF-5',
+        image: fixtures.inputJpgWithLandscapeExif5
+      },
+      {
+        name: 'EXIF-6',
+        image: fixtures.inputJpgWithLandscapeExif6
+      },
+      {
+        name: 'EXIF-7',
+        image: fixtures.inputJpgWithLandscapeExif7
+      },
+      {
+        name: 'EXIF-8',
+        image: fixtures.inputJpgWithLandscapeExif8
+      }
+    ].forEach(({ name, image }) => {
+      it(name, function (done) {
+        sharp(image)
+          .rotate()
+          .extract({ left: 0, top: 208, width: 60, height: 40 })
+          .toBuffer(function (err, data) {
+            if (err) throw err;
+            fixtures.assertSimilar(fixtures.expected('rotate-mirror-extract.jpg'), data, done);
+          });
       });
+    });
   });
 
   describe('Invalid parameters', function () {


### PR DESCRIPTION
the fix for #3024 isn't handling exif orientation 2 correctly

orientation 2 is flipped but has no rotation and wasn't applied correctly because of that