### PR TITLE
docs(input): correct getNormalSize with EXIF orientation example

### DIFF
--- a/docs/api-input.md
+++ b/docs/api-input.md
@@ -69,7 +69,7 @@ image
 const size = getNormalSize(await sharp(input).metadata());
 
 function getNormalSize({ width, height, orientation }) {
-  return orientation || 0 >= 5
+  return (orientation || 0) >= 5
     ? { width: height, height: width }
     : { width, height };
 }

--- a/lib/input.js
+++ b/lib/input.js
@@ -357,7 +357,7 @@ function _isStreamInput () {
  * const size = getNormalSize(await sharp(input).metadata());
  *
  * function getNormalSize({ width, height, orientation }) {
- *   return orientation || 0 >= 5
+ *   return (orientation || 0) >= 5
  *     ? { width: height, height: width }
  *     : { width, height };
  * }


### PR DESCRIPTION
The example is wrong. `>=` has precedence over `||` so the example always switchs the width and height if orientation has non-zero value and this leads to incorrect size.

