### PR TITLE
Fix setting WebP effort to 0 in constructor #3259

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -495,7 +495,7 @@ function webp (options) {
     if (is.defined(options.smartSubsample)) {
       this._setBooleanOption('webpSmartSubsample', options.smartSubsample);
     }
-    const effort = options.effort || options.reductionEffort;
+    const effort = is.defined(options.effort) ? options.effort : options.reductionEffort;
     if (is.defined(effort)) {
       if (is.integer(effort) && is.inRange(effort, 0, 6)) {
         this.options.webpEffort = effort;

--- a/test/unit/webp.js
+++ b/test/unit/webp.js
@@ -133,6 +133,12 @@ describe('WebP', function () {
     });
   });
 
+  it('should set effort to 0', () => {
+    const effort = sharp().webp({ effort: 0 }).options.webpEffort;
+
+    assert.strictEqual(effort, 0);
+  });
+
   it('invalid loop throws', () => {
     assert.throws(() => {
       sharp().webp({ loop: -1 });


### PR DESCRIPTION
Setting WebP effort to 0 in the constructor caused the effort to use the
default value of 4.