### PR TITLE
Use vips to upsample webp 

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -188,8 +188,10 @@ class PipelineWorker : public Napi::AsyncWorker {
           if (jpegShrinkOnLoad > 1 && static_cast<int>(shrink) == jpegShrinkOnLoad) {
             jpegShrinkOnLoad /= 2;
           }
-        } else if (inputImageType == sharp::ImageType::WEBP ||
-                   inputImageType == sharp::ImageType::SVG ||
+        } else if (inputImageType == sharp::ImageType::WEBP && shrink > 1.0) {
+          // Avoid upscaling via webp
+          scale = 1.0 / shrink;
+        } else if (inputImageType == sharp::ImageType::SVG ||
                    inputImageType == sharp::ImageType::PDF) {
           scale = 1.0 / shrink;
         }
@@ -217,7 +219,7 @@ class PipelineWorker : public Napi::AsyncWorker {
           ->set("access", baton->input->access)
           ->set("scale", scale)
           ->set("fail_on", baton->input->failOn);
-        if (scale < 1.0 && inputImageType == sharp::ImageType::WEBP) {
+        if (inputImageType == sharp::ImageType::WEBP) {
           option->set("n", baton->input->pages);
           option->set("page", baton->input->page);
 

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -217,7 +217,7 @@ class PipelineWorker : public Napi::AsyncWorker {
           ->set("access", baton->input->access)
           ->set("scale", scale)
           ->set("fail_on", baton->input->failOn);
-        if (inputImageType == sharp::ImageType::WEBP) {
+        if (scale < 1.0 && inputImageType == sharp::ImageType::WEBP) {
           option->set("n", baton->input->pages);
           option->set("page", baton->input->page);
 

--- a/test/unit/resize.js
+++ b/test/unit/resize.js
@@ -121,6 +121,20 @@ describe('Resize dimensions', function () {
       });
   });
 
+  it('Webp resize then extract large image', function (done) {
+    sharp(fixtures.inputWebP)
+      .resize(0x4000, 0x4000)
+      .extract({ top: 0x2000, left: 0x2000, width: 256, height: 256 })
+      .webp()
+      .toBuffer(function (err, data, info) {
+        if (err) throw err;
+        assert.strictEqual('webp', info.format);
+        assert.strictEqual(256, info.width);
+        assert.strictEqual(256, info.height);
+        done();
+      });
+  });
+
   it('WebP shrink-on-load rounds to zero, ensure recalculation is correct', function (done) {
     sharp(fixtures.inputJpg)
       .resize(1080, 607)


### PR DESCRIPTION
When scaling WebP images up past 16383 x 16383 use vips scaling logic to prevent `Error: webp: bad image dimensions`


Fixes #3262