### PR TITLE
CI: update macos runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,14 @@ jobs:
             container: node:14-alpine3.13
           - os: ubuntu-20.04
             container: node:16-alpine3.11
-          - os: macos-10.15
+          - os: macos-latest
             nodejs_version: 12
             prebuild: true
             nodejs_arch: x64
-          - os: macos-10.15
+          - os: macos-latest
             nodejs_version: 14
             nodejs_arch: x64
-          - os: macos-10.15
+          - os: macos-latest
             nodejs_version: 16
             nodejs_arch: x64
           - os: windows-2019


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/