### PR TITLE
package.json: add node-gyp as an optional peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,14 @@
     "rimraf": "^3.0.2",
     "semistandard": "^16.0.1"
   },
+  "peerDependencies": { 
+    "node-gyp": "*"
+  },
+  "peerDependenciesMeta": {
+    "node-gyp": {
+      "optional": true
+    }
+  },
   "license": "Apache-2.0",
   "config": {
     "libvips": "8.12.2",


### PR DESCRIPTION
This way, the implicit dependency on node-gyp for local builds is explicit, and build tools like dream2nix don't need workarounds to add it :-)