### PR TITLE
Include TypeScript definitions in bundle

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,6 +33,7 @@ To test C++ changes, you can compile the module using `npm install --build-from-
 
 Please add JavaScript [unit tests](https://github.com/lovell/sharp/tree/main/test/unit) to cover your new feature.
 A test coverage report for the JavaScript code is generated in the `coverage/lcov-report` directory.
+Please also update the [TypeScript definitions](https://github.com/lovell/sharp/tree/main/lib/index.d.ts), along with the [type definition tests](https://github.com/lovell/sharp/tree/main/test/types/sharp.test-d.ts).
 
 Where possible, the functional tests use gradient-based perceptual hashes
 based on [dHash](http://www.hackerfactor.com/blog/index.php?/archives/529-Kind-of-Like-That.html)

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,1567 @@
+/**
+ * Type definitions originally lifted from `@types/sharp`, MIT-licensed.
+ *
+ * Original definition authors:
+ *  - Wooseop Kim <https://github.com/wooseopkim>
+ *  - Bradley Odell <https://github.com/BTOdell>
+ *  - Jamie Woodbury <https://github.com/JamieWoodbury>
+ *  - Floris de Bijl <https://github.com/Fdebijl>
+ *  - Billy Kwok <https://github.com/billykwok>
+ *  - Espen Hovlandsdal <https://github.com/rexxars>
+ *  - Adam Kwiatek <https://github.com/akwiatek>
+ */
+
+/// <reference types="node" />
+
+import { Duplex } from 'stream';
+
+//#region Constructor functions
+
+/**
+ * Creates a sharp instance from an image
+ * @param input Buffer containing JPEG, PNG, WebP, AVIF, GIF, SVG, TIFF or raw pixel image data, or String containing the path to an JPEG, PNG, WebP, AVIF, GIF, SVG or TIFF image file.
+ * @param options Object with optional attributes.
+ * @throws {Error} Invalid parameters
+ * @returns A sharp instance that can be used to chain operations
+ */
+declare function sharp(options?: sharp.SharpOptions): sharp.Sharp;
+declare function sharp(
+    input?:
+        | Buffer
+        | Uint8Array
+        | Uint8ClampedArray
+        | Int8Array
+        | Uint16Array
+        | Int16Array
+        | Uint32Array
+        | Int32Array
+        | Float32Array
+        | Float64Array
+        | string,
+    options?: sharp.SharpOptions,
+): sharp.Sharp;
+
+declare namespace sharp {
+    /** Object containing nested boolean values representing the available input and output formats/methods. */
+    const format: FormatEnum;
+
+    /** An Object containing the version numbers of libvips and its dependencies. */
+    const versions: {
+        vips: string;
+        cairo?: string | undefined;
+        croco?: string | undefined;
+        exif?: string | undefined;
+        expat?: string | undefined;
+        ffi?: string | undefined;
+        fontconfig?: string | undefined;
+        freetype?: string | undefined;
+        gdkpixbuf?: string | undefined;
+        gif?: string | undefined;
+        glib?: string | undefined;
+        gsf?: string | undefined;
+        harfbuzz?: string | undefined;
+        jpeg?: string | undefined;
+        lcms?: string | undefined;
+        orc?: string | undefined;
+        pango?: string | undefined;
+        pixman?: string | undefined;
+        png?: string | undefined;
+        svg?: string | undefined;
+        tiff?: string | undefined;
+        webp?: string | undefined;
+        avif?: string | undefined;
+        heif?: string | undefined;
+        xml?: string | undefined;
+        zlib?: string | undefined;
+    };
+
+    /** An Object containing the platform and architecture of the current and installed vendored binaries. */
+    const vendor: {
+        current: string;
+        installed: string[];
+    };
+
+    /** An Object containing the available interpolators and their proper values */
+    const interpolators: Interpolators;
+
+    /** An EventEmitter that emits a change event when a task is either queued, waiting for libuv to provide a worker thread, complete */
+    const queue: NodeJS.EventEmitter;
+
+    //#endregion
+
+    //#region Utility functions
+
+    /**
+     * Gets or, when options are provided, sets the limits of libvips' operation cache.
+     * Existing entries in the cache will be trimmed after any change in limits.
+     * This method always returns cache statistics, useful for determining how much working memory is required for a particular task.
+     * @param options Object with the following attributes, or Boolean where true uses default cache settings and false removes all caching (optional, default true)
+     * @returns The cache results.
+     */
+    function cache(options?: boolean | CacheOptions): CacheResult;
+
+    /**
+     * Gets or sets the number of threads libvips' should create to process each image.
+     * The default value is the number of CPU cores. A value of 0 will reset to this default.
+     * The maximum number of images that can be processed in parallel is limited by libuv's UV_THREADPOOL_SIZE environment variable.
+     * @param concurrency The new concurrency value.
+     * @returns The current concurrency value.
+     */
+    function concurrency(concurrency?: number): number;
+
+    /**
+     * Provides access to internal task counters.
+     * @returns Object containing task counters
+     */
+    function counters(): SharpCounters;
+
+    /**
+     * Get and set use of SIMD vector unit instructions. Requires libvips to have been compiled with liborc support.
+     * Improves the performance of resize, blur and sharpen operations by taking advantage of the SIMD vector unit of the CPU, e.g. Intel SSE and ARM NEON.
+     * @param enable enable or disable use of SIMD vector unit instructions
+     * @returns true if usage of SIMD vector unit instructions is enabled
+     */
+    function simd(enable?: boolean): boolean;
+
+    //#endregion
+
+    const gravity: GravityEnum;
+    const strategy: StrategyEnum;
+    const kernel: KernelEnum;
+    const fit: FitEnum;
+    const bool: BoolEnum;
+
+    interface Sharp extends Duplex {
+        //#region Channel functions
+
+        /**
+         * Remove alpha channel, if any. This is a no-op if the image does not have an alpha channel.
+         * @returns A sharp instance that can be used to chain operations
+         */
+        removeAlpha(): Sharp;
+
+        /**
+         * Ensure alpha channel, if missing. The added alpha channel will be fully opaque. This is a no-op if the image already has an alpha channel.
+         * @param alpha transparency level (0=fully-transparent, 1=fully-opaque) (optional, default 1).
+         * @returns A sharp instance that can be used to chain operations
+         */
+        ensureAlpha(alpha?: number): Sharp;
+
+        /**
+         * Extract a single channel from a multi-channel image.
+         * @param channel zero-indexed channel/band number to extract, or red, green, blue or alpha.
+         * @throws {Error} Invalid channel
+         * @returns A sharp instance that can be used to chain operations
+         */
+        extractChannel(channel: 0 | 1 | 2 | 3 | 'red' | 'green' | 'blue' | 'alpha'): Sharp;
+
+        /**
+         * Join one or more channels to the image. The meaning of the added channels depends on the output colourspace, set with toColourspace().
+         * By default the output image will be web-friendly sRGB, with additional channels interpreted as alpha channels. Channel ordering follows vips convention:
+         *  - sRGB: 0: Red, 1: Green, 2: Blue, 3: Alpha.
+         *  - CMYK: 0: Magenta, 1: Cyan, 2: Yellow, 3: Black, 4: Alpha.
+         *
+         * Buffers may be any of the image formats supported by sharp.
+         * For raw pixel input, the options object should contain a raw attribute, which follows the format of the attribute of the same name in the sharp() constructor.
+         * @param images one or more images (file paths, Buffers).
+         * @param options image options, see sharp() constructor.
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        joinChannel(images: string | Buffer | ArrayLike<string | Buffer>, options?: SharpOptions): Sharp;
+
+        /**
+         * Perform a bitwise boolean operation on all input image channels (bands) to produce a single channel output image.
+         * @param boolOp one of "and", "or" or "eor" to perform that bitwise operation, like the C logic operators &, | and ^ respectively.
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        bandbool(boolOp: keyof BoolEnum): Sharp;
+
+        //#endregion
+
+        //#region Color functions
+
+        /**
+         * Tint the image using the provided chroma while preserving the image luminance.
+         * An alpha channel may be present and will be unchanged by the operation.
+         * @param rgb Parsed by the color module to extract chroma values.
+         * @returns A sharp instance that can be used to chain operations
+         */
+        tint(rgb: Color): Sharp;
+
+        /**
+         * Convert to 8-bit greyscale; 256 shades of grey.
+         * This is a linear operation.
+         * If the input image is in a non-linear colour space such as sRGB, use gamma() with greyscale() for the best results.
+         * By default the output image will be web-friendly sRGB and contain three (identical) color channels.
+         * This may be overridden by other sharp operations such as toColourspace('b-w'), which will produce an output image containing one color channel.
+         * An alpha channel may be present, and will be unchanged by the operation.
+         * @param greyscale true to enable and false to disable (defaults to true)
+         * @returns A sharp instance that can be used to chain operations
+         */
+        greyscale(greyscale?: boolean): Sharp;
+
+        /**
+         * Alternative spelling of greyscale().
+         * @param grayscale true to enable and false to disable (defaults to true)
+         * @returns A sharp instance that can be used to chain operations
+         */
+        grayscale(grayscale?: boolean): Sharp;
+
+        /**
+         * Set the pipeline colourspace.
+         * The input image will be converted to the provided colourspace at the start of the pipeline.
+         * All operations will use this colourspace before converting to the output colourspace, as defined by toColourspace.
+         * This feature is experimental and has not yet been fully-tested with all operations.
+         *
+         * @param colourspace pipeline colourspace e.g. rgb16, scrgb, lab, grey16 ...
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        pipelineColourspace(colourspace?: string): Sharp;
+
+        /**
+         * Alternative spelling of pipelineColourspace
+         * @param colorspace pipeline colourspace e.g. rgb16, scrgb, lab, grey16 ...
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        pipelineColorspace(colorspace?: string): Sharp;
+
+        /**
+         * Set the output colourspace.
+         * By default output image will be web-friendly sRGB, with additional channels interpreted as alpha channels.
+         * @param colourspace output colourspace e.g. srgb, rgb, cmyk, lab, b-w ...
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        toColourspace(colourspace?: string): Sharp;
+
+        /**
+         * Alternative spelling of toColourspace().
+         * @param colorspace output colorspace e.g. srgb, rgb, cmyk, lab, b-w ...
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        toColorspace(colorspace: string): Sharp;
+
+        //#endregion
+
+        //#region Composite functions
+
+        /**
+         * Composite image(s) over the processed (resized, extracted etc.) image.
+         *
+         * The images to composite must be the same size or smaller than the processed image.
+         * If both `top` and `left` options are provided, they take precedence over `gravity`.
+         * @param images - Ordered list of images to composite
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        composite(images: OverlayOptions[]): Sharp;
+
+        //#endregion
+
+        //#region Input functions
+
+        /**
+         * Take a "snapshot" of the Sharp instance, returning a new instance.
+         * Cloned instances inherit the input of their parent instance.
+         * This allows multiple output Streams and therefore multiple processing pipelines to share a single input Stream.
+         * @returns A sharp instance that can be used to chain operations
+         */
+        clone(): Sharp;
+
+        /**
+         * Fast access to (uncached) image metadata without decoding any compressed image data.
+         * @returns A sharp instance that can be used to chain operations
+         */
+        metadata(callback: (err: Error, metadata: Metadata) => void): Sharp;
+
+        /**
+         * Fast access to (uncached) image metadata without decoding any compressed image data.
+         * @returns A promise that resolves with a metadata object
+         */
+        metadata(): Promise<Metadata>;
+
+        /**
+         * Access to pixel-derived image statistics for every channel in the image.
+         * @returns A sharp instance that can be used to chain operations
+         */
+        stats(callback: (err: Error, stats: Stats) => void): Sharp;
+
+        /**
+         * Access to pixel-derived image statistics for every channel in the image.
+         * @returns A promise that resolves with a stats object
+         */
+        stats(): Promise<Stats>;
+
+        //#endregion
+
+        //#region Operation functions
+
+        /**
+         * Rotate the output image by either an explicit angle or auto-orient based on the EXIF Orientation tag.
+         *
+         * If an angle is provided, it is converted to a valid positive degree rotation. For example, -450 will produce a 270deg rotation.
+         *
+         * When rotating by an angle other than a multiple of 90, the background colour can be provided with the background option.
+         *
+         * If no angle is provided, it is determined from the EXIF data. Mirroring is supported and may infer the use of a flip operation.
+         *
+         * The use of rotate implies the removal of the EXIF Orientation tag, if any.
+         *
+         * Method order is important when both rotating and extracting regions, for example rotate(x).extract(y) will produce a different result to extract(y).rotate(x).
+         * @param angle angle of rotation. (optional, default auto)
+         * @param options if present, is an Object with optional attributes.
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        rotate(angle?: number, options?: RotateOptions): Sharp;
+
+        /**
+         * Flip the image about the vertical Y axis. This always occurs after rotation, if any.
+         * The use of flip implies the removal of the EXIF Orientation tag, if any.
+         * @param flip true to enable and false to disable (defaults to true)
+         * @returns A sharp instance that can be used to chain operations
+         */
+        flip(flip?: boolean): Sharp;
+
+        /**
+         * Flop the image about the horizontal X axis. This always occurs after rotation, if any.
+         * The use of flop implies the removal of the EXIF Orientation tag, if any.
+         * @param flop true to enable and false to disable (defaults to true)
+         * @returns A sharp instance that can be used to chain operations
+         */
+        flop(flop?: boolean): Sharp;
+
+        /**
+         * Perform an affine transform on an image. This operation will always occur after resizing, extraction and rotation, if any.
+         * You must provide an array of length 4 or a 2x2 affine transformation matrix.
+         * By default, new pixels are filled with a black background. You can provide a background color with the `background` option.
+         * A particular interpolator may also be specified. Set the `interpolator` option to an attribute of the `sharp.interpolator` Object e.g. `sharp.interpolator.nohalo`.
+         *
+         * In the case of a 2x2 matrix, the transform is:
+         * X = matrix[0, 0] * (x + idx) + matrix[0, 1] * (y + idy) + odx
+         * Y = matrix[1, 0] * (x + idx) + matrix[1, 1] * (y + idy) + ody
+         *
+         * where:
+         *
+         * x and y are the coordinates in input image.
+         * X and Y are the coordinates in output image.
+         * (0,0) is the upper left corner.
+         *
+         * @param matrix Affine transformation matrix, may either by a array of length four or a 2x2 matrix array
+         * @param options if present, is an Object with optional attributes.
+         *
+         * @returns A sharp instance that can be used to chain operations
+         */
+        affine(matrix: [number, number, number, number] | Matrix2x2, options?: AffineOptions): Sharp;
+
+        /**
+         * Sharpen the image.
+         * When used without parameters, performs a fast, mild sharpen of the output image.
+         * When a sigma is provided, performs a slower, more accurate sharpen of the L channel in the LAB colour space.
+         * Fine-grained control over the level of sharpening in "flat" (m1) and "jagged" (m2) areas is available.
+         * @param options if present, is an Object with optional attributes
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        sharpen(options?: SharpenOptions): Sharp;
+
+        /**
+         * Sharpen the image.
+         * When used without parameters, performs a fast, mild sharpen of the output image.
+         * When a sigma is provided, performs a slower, more accurate sharpen of the L channel in the LAB colour space.
+         * Fine-grained control over the level of sharpening in "flat" (m1) and "jagged" (m2) areas is available.
+         * @param sigma the sigma of the Gaussian mask, where sigma = 1 + radius / 2.
+         * @param flat the level of sharpening to apply to "flat" areas. (optional, default 1.0)
+         * @param jagged the level of sharpening to apply to "jagged" areas. (optional, default 2.0)
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         *
+         * @deprecated Use the object parameter `sharpen({sigma, m1, m2, x1, y2, y3})` instead
+         */
+        sharpen(sigma?: number, flat?: number, jagged?: number): Sharp;
+
+        /**
+         * Apply median filter. When used without parameters the default window is 3x3.
+         * @param size square mask size: size x size (optional, default 3)
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        median(size?: number): Sharp;
+
+        /**
+         * Blur the image.
+         * When used without parameters, performs a fast, mild blur of the output image.
+         * When a sigma is provided, performs a slower, more accurate Gaussian blur.
+         * When a boolean sigma is provided, ether blur mild or disable blur
+         * @param sigma a value between 0.3 and 1000 representing the sigma of the Gaussian mask, where sigma = 1 + radius / 2.
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        blur(sigma?: number | boolean): Sharp;
+
+        /**
+         * Merge alpha transparency channel, if any, with background.
+         * @param flatten true to enable and false to disable (defaults to true)
+         * @returns A sharp instance that can be used to chain operations
+         */
+        flatten(flatten?: boolean | FlattenOptions): Sharp;
+
+        /**
+         * Apply a gamma correction by reducing the encoding (darken) pre-resize at a factor of 1/gamma then increasing the encoding (brighten) post-resize at a factor of gamma.
+         * This can improve the perceived brightness of a resized image in non-linear colour spaces.
+         * JPEG and WebP input images will not take advantage of the shrink-on-load performance optimisation when applying a gamma correction.
+         * Supply a second argument to use a different output gamma value, otherwise the first value is used in both cases.
+         * @param gamma value between 1.0 and 3.0. (optional, default 2.2)
+         * @param gammaOut value between 1.0 and 3.0. (optional, defaults to same as gamma)
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        gamma(gamma?: number, gammaOut?: number): Sharp;
+
+        /**
+         * Produce the "negative" of the image.
+         * @param negate true to enable and false to disable, or an object of options (defaults to true)
+         * @returns A sharp instance that can be used to chain operations
+         */
+        negate(negate?: boolean | NegateOptions): Sharp;
+
+        /**
+         * Enhance output image contrast by stretching its luminance to cover the full dynamic range.
+         * @param normalise true to enable and false to disable (defaults to true)
+         * @returns A sharp instance that can be used to chain operations
+         */
+        normalise(normalise?: boolean): Sharp;
+
+        /**
+         * Alternative spelling of normalise.
+         * @param normalize true to enable and false to disable (defaults to true)
+         * @returns A sharp instance that can be used to chain operations
+         */
+        normalize(normalize?: boolean): Sharp;
+
+        /**
+         * Perform contrast limiting adaptive histogram equalization (CLAHE)
+         *
+         * This will, in general, enhance the clarity of the image by bringing out
+         * darker details. Please read more about CLAHE here:
+         * https://en.wikipedia.org/wiki/Adaptive_histogram_equalization#Contrast_Limited_AHE
+         *
+         * @param options clahe options
+         */
+        clahe(options: ClaheOptions): Sharp;
+
+        /**
+         * Convolve the image with the specified kernel.
+         * @param kernel the specified kernel
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        convolve(kernel: Kernel): Sharp;
+
+        /**
+         * Any pixel value greather than or equal to the threshold value will be set to 255, otherwise it will be set to 0.
+         * @param threshold a value in the range 0-255 representing the level at which the threshold will be applied. (optional, default 128)
+         * @param options threshold options
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        threshold(threshold?: number, options?: ThresholdOptions): Sharp;
+
+        /**
+         * Perform a bitwise boolean operation with operand image.
+         * This operation creates an output image where each pixel is the result of the selected bitwise boolean operation between the corresponding pixels of the input images.
+         * @param operand Buffer containing image data or String containing the path to an image file.
+         * @param operator one of "and", "or" or "eor" to perform that bitwise operation, like the C logic operators &, | and ^ respectively.
+         * @param options describes operand when using raw pixel data.
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        boolean(operand: string | Buffer, operator: keyof BoolEnum, options?: { raw: Raw }): Sharp;
+
+        /**
+         * Apply the linear formula a * input + b to the image (levels adjustment)
+         * @param a multiplier (optional, default 1.0)
+         * @param b offset (optional, default 0.0)
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        linear(a?: number | number[] | null, b?: number | number[]): Sharp;
+
+        /**
+         * Recomb the image with the specified matrix.
+         * @param inputMatrix 3x3 Recombination matrix
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        recomb(inputMatrix: Matrix3x3): Sharp;
+
+        /**
+         * Transforms the image using brightness, saturation, hue rotation and lightness.
+         * Brightness and lightness both operate on luminance, with the difference being that brightness is multiplicative whereas lightness is additive.
+         * @param options describes the modulation
+         * @returns A sharp instance that can be used to chain operations
+         */
+        modulate(options?: {
+            brightness?: number | undefined;
+            saturation?: number | undefined;
+            hue?: number | undefined;
+            lightness?: number | undefined;
+        }): Sharp;
+
+        //#endregion
+
+        //#region Output functions
+
+        /**
+         * Write output image data to a file.
+         * If an explicit output format is not selected, it will be inferred from the extension, with JPEG, PNG, WebP, AVIF, TIFF, DZI, and libvips' V format supported.
+         * Note that raw pixel data is only supported for buffer output.
+         * @param fileOut The path to write the image data to.
+         * @param callback Callback function called on completion with two arguments (err, info).  info contains the output image format, size (bytes), width, height and channels.
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        toFile(fileOut: string, callback: (err: Error, info: OutputInfo) => void): Sharp;
+
+        /**
+         * Write output image data to a file.
+         * @param fileOut The path to write the image data to.
+         * @throws {Error} Invalid parameters
+         * @returns A promise that fulfills with an object containing information on the resulting file
+         */
+        toFile(fileOut: string): Promise<OutputInfo>;
+
+        /**
+         * Write output to a Buffer. JPEG, PNG, WebP, AVIF, TIFF, GIF and RAW output are supported.
+         * By default, the format will match the input image, except SVG input which becomes PNG output.
+         * @param callback Callback function called on completion with three arguments (err, buffer, info).
+         * @returns A sharp instance that can be used to chain operations
+         */
+        toBuffer(callback: (err: Error, buffer: Buffer, info: OutputInfo) => void): Sharp;
+
+        /**
+         * Write output to a Buffer. JPEG, PNG, WebP, AVIF, TIFF, GIF and RAW output are supported.
+         * By default, the format will match the input image, except SVG input which becomes PNG output.
+         * @param options resolve options
+         * @param options.resolveWithObject Resolve the Promise with an Object containing data and info properties instead of resolving only with data.
+         * @returns A promise that resolves with the Buffer data.
+         */
+        toBuffer(options?: { resolveWithObject: false }): Promise<Buffer>;
+
+        /**
+         * Write output to a Buffer. JPEG, PNG, WebP, AVIF, TIFF, GIF and RAW output are supported.
+         * By default, the format will match the input image, except SVG input which becomes PNG output.
+         * @param options resolve options
+         * @param options.resolveWithObject Resolve the Promise with an Object containing data and info properties instead of resolving only with data.
+         * @returns A promise that resolves with an object containing the Buffer data and an info object containing the output image format, size (bytes), width, height and channels
+         */
+        toBuffer(options: { resolveWithObject: true }): Promise<{ data: Buffer; info: OutputInfo }>;
+
+        /**
+         * Include all metadata (EXIF, XMP, IPTC) from the input image in the output image.
+         * The default behaviour, when withMetadata is not used, is to strip all metadata and convert to the device-independent sRGB colour space.
+         * This will also convert to and add a web-friendly sRGB ICC profile.
+         * @param withMetadata
+         * @throws {Error} Invalid parameters.
+         */
+        withMetadata(withMetadata?: WriteableMetadata): Sharp;
+
+        /**
+         * Use these JPEG options for output image.
+         * @param options Output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        jpeg(options?: JpegOptions): Sharp;
+
+        /**
+         * Use these JP2 (JPEG 2000) options for output image.
+         * @param options Output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        jp2(options?: Jp2Options): Sharp;
+
+        /**
+         * Use these JPEG-XL (JXL) options for output image.
+         * This feature is experimental, please do not use in production systems.
+         * Requires libvips compiled with support for libjxl.
+         * The prebuilt binaries do not include this.
+         * Image metadata (EXIF, XMP) is unsupported.
+         * @param options Output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        jxl(options?: JxlOptions): Sharp;
+
+        /**
+         * Use these PNG options for output image.
+         * PNG output is always full colour at 8 or 16 bits per pixel.
+         * Indexed PNG input at 1, 2 or 4 bits per pixel is converted to 8 bits per pixel.
+         * @param options Output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        png(options?: PngOptions): Sharp;
+
+        /**
+         * Use these WebP options for output image.
+         * @param options Output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        webp(options?: WebpOptions): Sharp;
+
+        /**
+         * Use these GIF options for output image.
+         * Requires libvips compiled with support for ImageMagick or GraphicsMagick. The prebuilt binaries do not include this - see installing a custom libvips.
+         * @param options Output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        gif(options?: GifOptions): Sharp;
+
+        /**
+         * Use these AVIF options for output image.
+         * Whilst it is possible to create AVIF images smaller than 16x16 pixels, most web browsers do not display these properly.
+         * @param options Output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        avif(options?: AvifOptions): Sharp;
+
+        /**
+         * Use these HEIF options for output image.
+         * Support for patent-encumbered HEIC images requires the use of a globally-installed libvips compiled with support for libheif, libde265 and x265.
+         * @param options Output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        heif(options?: HeifOptions): Sharp;
+
+        /**
+         * Use these TIFF options for output image.
+         * @param options Output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        tiff(options?: TiffOptions): Sharp;
+
+        /**
+         * Force output to be raw, uncompressed uint8 pixel data.
+         * @param options Raw output options.
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        raw(options?: RawOptions): Sharp;
+
+        /**
+         * Force output to a given format.
+         * @param format a String or an Object with an 'id' attribute
+         * @param options output options
+         * @throws {Error} Unsupported format or options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        toFormat(
+            format: keyof FormatEnum | AvailableFormatInfo,
+            options?:
+                | OutputOptions
+                | JpegOptions
+                | PngOptions
+                | WebpOptions
+                | AvifOptions
+                | HeifOptions
+                | JxlOptions
+                | GifOptions
+                | Jp2Options
+                | TiffOptions,
+        ): Sharp;
+
+        /**
+         * Use tile-based deep zoom (image pyramid) output.
+         * Set the format and options for tile images via the toFormat, jpeg, png or webp functions.
+         * Use a .zip or .szi file extension with toFile to write to a compressed archive file format.
+         *
+         * Warning: multiple sharp instances concurrently producing tile output can expose a possible race condition in some versions of libgsf.
+         * @param tile tile options
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        tile(tile?: TileOptions): Sharp;
+
+        /**
+         * Set a timeout for processing, in seconds. Use a value of zero to continue processing indefinitely, the default behaviour.
+         * The clock starts when libvips opens an input image for processing. Time spent waiting for a libuv thread to become available is not included.
+         * @param options Object with a `seconds` attribute between 0 and 3600 (number)
+         * @throws {Error} Invalid options
+         * @returns A sharp instance that can be used to chain operations
+         */
+        timeout(options: TimeoutOptions): Sharp;
+
+        //#endregion
+
+        //#region Resize functions
+
+        /**
+         * Resize image to width, height or width x height.
+         *
+         * When both a width and height are provided, the possible methods by which the image should fit these are:
+         *  - cover: Crop to cover both provided dimensions (the default).
+         *  - contain: Embed within both provided dimensions.
+         *  - fill: Ignore the aspect ratio of the input and stretch to both provided dimensions.
+         *  - inside: Preserving aspect ratio, resize the image to be as large as possible while ensuring its dimensions are less than or equal to both those specified.
+         *  - outside: Preserving aspect ratio, resize the image to be as small as possible while ensuring its dimensions are greater than or equal to both those specified.
+         *             Some of these values are based on the object-fit CSS property.
+         *
+         * When using a fit of cover or contain, the default position is centre. Other options are:
+         *  - sharp.position: top, right top, right, right bottom, bottom, left bottom, left, left top.
+         *  - sharp.gravity: north, northeast, east, southeast, south, southwest, west, northwest, center or centre.
+         *  - sharp.strategy: cover only, dynamically crop using either the entropy or attention strategy. Some of these values are based on the object-position CSS property.
+         *
+         * The experimental strategy-based approach resizes so one dimension is at its target length then repeatedly ranks edge regions,
+         * discarding the edge with the lowest score based on the selected strategy.
+         *  - entropy: focus on the region with the highest Shannon entropy.
+         *  - attention: focus on the region with the highest luminance frequency, colour saturation and presence of skin tones.
+         *
+         * Possible interpolation kernels are:
+         *  - nearest: Use nearest neighbour interpolation.
+         *  - cubic: Use a Catmull-Rom spline.
+         *  - lanczos2: Use a Lanczos kernel with a=2.
+         *  - lanczos3: Use a Lanczos kernel with a=3 (the default).
+         *
+         * @param width pixels wide the resultant image should be. Use null or undefined to auto-scale the width to match the height.
+         * @param height pixels high the resultant image should be. Use null or undefined to auto-scale the height to match the width.
+         * @param options resize options
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        resize(width?: number | null, height?: number | null, options?: ResizeOptions): Sharp;
+
+        /**
+         * Shorthand for resize(null, null, options);
+         *
+         * @param options resize options
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        resize(options: ResizeOptions): Sharp;
+
+        /**
+         * Extends/pads the edges of the image with the provided background colour.
+         * This operation will always occur after resizing and extraction, if any.
+         * @param extend single pixel count to add to all edges or an Object with per-edge counts
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        extend(extend: number | ExtendOptions): Sharp;
+
+        /**
+         * Extract a region of the image.
+         *  - Use extract() before resize() for pre-resize extraction.
+         *  - Use extract() after resize() for post-resize extraction.
+         *  - Use extract() before and after for both.
+         *
+         * @param region The region to extract
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        extract(region: Region): Sharp;
+
+        /**
+         * Trim pixels from all edges that contain values similar to the given background colour, which defaults to that of the top-left pixel.
+         * Images with an alpha channel will use the combined bounding box of alpha and non-alpha channels.
+         * The info response Object will contain trimOffsetLeft and trimOffsetTop properties.
+         * @param trim The specific background colour to trim, the threshold for doing so or an Object with both.
+         * @throws {Error} Invalid parameters
+         * @returns A sharp instance that can be used to chain operations
+         */
+        trim(trim?: string | number | TrimOptions): Sharp;
+
+        //#endregion
+    }
+
+    interface SharpOptions {
+        /**
+         *  When to abort processing of invalid pixel data, one of (in order of sensitivity):
+         *  'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels, invalid metadata will always abort. (optional, default 'warning')
+         */
+        failOn?: FailOnOptions | undefined;
+        /**
+         * By default halt processing and raise an error when loading invalid images.
+         * Set this flag to false if you'd rather apply a "best effort" to decode images,
+         * even if the data is corrupt or invalid. (optional, default true)
+         *
+         * @deprecated Use `failOn` instead
+         */
+        failOnError?: boolean | undefined;
+        /**
+         * Do not process input images where the number of pixels (width x height) exceeds this limit.
+         * Assumes image dimensions contained in the input metadata can be trusted.
+         * An integral Number of pixels, zero or false to remove limit, true to use default limit of 268402689 (0x3FFF x 0x3FFF). (optional, default 268402689)
+         */
+        limitInputPixels?: number | boolean | undefined;
+        /** Set this to true to remove safety features that help prevent memory exhaustion (SVG, PNG). (optional, default false) */
+        unlimited?: boolean | undefined;
+        /** Set this to true to use sequential rather than random access where possible. This can reduce memory usage and might improve performance on some systems. (optional, default false) */
+        sequentialRead?: boolean | undefined;
+        /** Number representing the DPI for vector images in the range 1 to 100000. (optional, default 72) */
+        density?: number | undefined;
+        /** Number of pages to extract for multi-page input (GIF, TIFF, PDF), use -1 for all pages */
+        pages?: number | undefined;
+        /** Page number to start extracting from for multi-page input (GIF, TIFF, PDF), zero based. (optional, default 0) */
+        page?: number | undefined;
+        /** subIFD (Sub Image File Directory) to extract for OME-TIFF, defaults to main image. (optional, default -1) */
+        subifd?: number | undefined;
+        /** Level to extract from a multi-level input (OpenSlide), zero based. (optional, default 0) */
+        level?: number | undefined;
+        /** Set to `true` to read all frames/pages of an animated image (equivalent of setting `pages` to `-1`). (optional, default false) */
+        animated?: boolean | undefined;
+        /** Describes raw pixel input image data. See raw() for pixel ordering. */
+        raw?: CreateRaw | undefined;
+        /** Describes a new image to be created. */
+        create?: Create | undefined;
+        /** Describes a new text image to be created. */
+        text?: CreateText | undefined;
+    }
+
+    interface CacheOptions {
+        /** Is the maximum memory in MB to use for this cache (optional, default 50) */
+        memory?: number | undefined;
+        /** Is the maximum number of files to hold open (optional, default 20) */
+        files?: number | undefined;
+        /** Is the maximum number of operations to cache (optional, default 100) */
+        items?: number | undefined;
+    }
+
+    interface TimeoutOptions {
+        /** Number of seconds after which processing will be stopped (default 0, eg disabled) */
+        seconds: number;
+    }
+
+    interface SharpCounters {
+        /** The number of tasks this module has queued waiting for libuv to provide a worker thread from its pool. */
+        queue: number;
+        /** The number of resize tasks currently being processed. */
+        process: number;
+    }
+
+    interface Raw {
+        width: number;
+        height: number;
+        channels: 1 | 2 | 3 | 4;
+    }
+
+    interface CreateRaw extends Raw {
+        /** Specifies that the raw input has already been premultiplied, set to true to avoid sharp premultiplying the image. (optional, default false) */
+        premultiplied?: boolean | undefined;
+    }
+
+    interface Create {
+        /** Number of pixels wide. */
+        width: number;
+        /** Number of pixels high. */
+        height: number;
+        /** Number of bands e.g. 3 for RGB, 4 for RGBA */
+        channels: Channels;
+        /** Parsed by the [color](https://www.npmjs.org/package/color) module to extract values for red, green, blue and alpha. */
+        background: Color;
+        /** Describes a noise to be created. */
+        noise?: Noise | undefined;
+    }
+
+    interface CreateText {
+        /** Text to render as a UTF-8 string. It can contain Pango markup, for example `<i>Le</i>Monde`. */
+        text: string;
+        /** Font name to render with. */
+        font?: string;
+        /** Absolute filesystem path to a font file that can be used by `font`. */
+        fontfile?: string;
+        /** Integral number of pixels to word-wrap at. Lines of text wider than this will be broken at word boundaries. (optional, default `0`) */
+        width?: number;
+        /**
+         * Integral number of pixels high. When defined, `dpi` will be ignored and the text will automatically fit the pixel resolution
+         * defined by `width` and `height`. Will be ignored if `width` is not specified or set to 0. (optional, default `0`)
+         */
+        height?: number;
+        /** Text alignment ('left', 'centre', 'center', 'right'). (optional, default 'left') */
+        align?: TextAlign;
+        /** Set this to true to apply justification to the text. (optional, default `false`) */
+        justify?: boolean;
+        /** The resolution (size) at which to render the text. Does not take effect if `height` is specified. (optional, default `72`) */
+        dpi?: number;
+        /**
+         * Set this to true to enable RGBA output. This is useful for colour emoji rendering,
+         * or support for pango markup features like `<span foreground="red">Red!</span>`. (optional, default `false`)
+         */
+        rgba?: boolean;
+        /** Text line height in points. Will use the font line height if none is specified. (optional, default `0`) */
+        spacing?: number;
+    }
+
+    interface WriteableMetadata {
+        /** Value between 1 and 8, used to update the EXIF Orientation tag. */
+        orientation?: number | undefined;
+        /** Filesystem path to output ICC profile, defaults to sRGB. */
+        icc?: string | undefined;
+        /** Object keyed by IFD0, IFD1 etc. of key/value string pairs to write as EXIF data. (optional, default {}) */
+        exif?: Record<string, any> | undefined;
+        /** Number of pixels per inch (DPI) */
+        density?: number | undefined;
+    }
+
+    interface Metadata {
+        /** Number value of the EXIF Orientation header, if present */
+        orientation?: number | undefined;
+        /** Name of decoder used to decompress image data e.g. jpeg, png, webp, gif, svg */
+        format?: keyof FormatEnum | undefined;
+        /** Total size of image in bytes, for Stream and Buffer input only */
+        size?: number | undefined;
+        /** Number of pixels wide (EXIF orientation is not taken into consideration) */
+        width?: number | undefined;
+        /** Number of pixels high (EXIF orientation is not taken into consideration) */
+        height?: number | undefined;
+        /** Name of colour space interpretation */
+        space?: keyof ColourspaceEnum | undefined;
+        /** Number of bands e.g. 3 for sRGB, 4 for CMYK */
+        channels?: Channels | undefined;
+        /** Name of pixel depth format e.g. uchar, char, ushort, float ... */
+        depth?: string | undefined;
+        /** Number of pixels per inch (DPI), if present */
+        density?: number | undefined;
+        /** String containing JPEG chroma subsampling, 4:2:0 or 4:4:4 for RGB, 4:2:0:4 or 4:4:4:4 for CMYK */
+        chromaSubsampling: string;
+        /** Boolean indicating whether the image is interlaced using a progressive scan */
+        isProgressive?: boolean | undefined;
+        /** Number of pages/frames contained within the image, with support for TIFF, HEIF, PDF, animated GIF and animated WebP */
+        pages?: number | undefined;
+        /** Number of pixels high each page in a multi-page image will be. */
+        pageHeight?: number | undefined;
+        /** Number of times to loop an animated image, zero refers to a continuous loop. */
+        loop?: number | undefined;
+        /** Delay in ms between each page in an animated image, provided as an array of integers. */
+        delay?: number[] | undefined;
+        /**  Number of the primary page in a HEIF image */
+        pagePrimary?: number | undefined;
+        /** Boolean indicating the presence of an embedded ICC profile */
+        hasProfile?: boolean | undefined;
+        /** Boolean indicating the presence of an alpha transparency channel */
+        hasAlpha?: boolean | undefined;
+        /** Buffer containing raw EXIF data, if present */
+        exif?: Buffer | undefined;
+        /** Buffer containing raw ICC profile data, if present */
+        icc?: Buffer | undefined;
+        /** Buffer containing raw IPTC data, if present */
+        iptc?: Buffer | undefined;
+        /** Buffer containing raw XMP data, if present */
+        xmp?: Buffer | undefined;
+        /** Buffer containing raw TIFFTAG_PHOTOSHOP data, if present */
+        tifftagPhotoshop?: Buffer | undefined;
+        /** The encoder used to compress an HEIF file, `av1` (AVIF) or `hevc` (HEIC) */
+        compression?: 'av1' | 'hevc';
+        /** Default background colour, if present, for PNG (bKGD) and GIF images, either an RGB Object or a single greyscale value */
+        background?: { r: number; g: number; b: number } | number;
+        /** Details of each level in a multi-level image provided as an array of objects, requires libvips compiled with support for OpenSlide */
+        levels?: LevelMetadata[] | undefined;
+        /** Number of Sub Image File Directories in an OME-TIFF image */
+        subifds?: number | undefined;
+        /** The unit of resolution (density) */
+        resolutionUnit?: 'inch' | 'cm' | undefined;
+    }
+
+    interface LevelMetadata {
+        width: number;
+        height: number;
+    }
+
+    interface Stats {
+        /** Array of channel statistics for each channel in the image. */
+        channels: ChannelStats[];
+        /** Value to identify if the image is opaque or transparent, based on the presence and use of alpha channel */
+        isOpaque: boolean;
+        /** Histogram-based estimation of greyscale entropy, discarding alpha channel if any (experimental) */
+        entropy: number;
+        /** Estimation of greyscale sharpness based on the standard deviation of a Laplacian convolution, discarding alpha channel if any (experimental) */
+        sharpness: number;
+        /** Object containing most dominant sRGB colour based on a 4096-bin 3D histogram (experimental) */
+        dominant: { r: number; g: number; b: number };
+    }
+
+    interface ChannelStats {
+        /** minimum value in the channel */
+        min: number;
+        /** maximum value in the channel */
+        max: number;
+        /** sum of all values in a channel */
+        sum: number;
+        /** sum of squared values in a channel */
+        squaresSum: number;
+        /** mean of the values in a channel */
+        mean: number;
+        /** standard deviation for the values in a channel */
+        stdev: number;
+        /** x-coordinate of one of the pixel where the minimum lies */
+        minX: number;
+        /** y-coordinate of one of the pixel where the minimum lies */
+        minY: number;
+        /** x-coordinate of one of the pixel where the maximum lies */
+        maxX: number;
+        /** y-coordinate of one of the pixel where the maximum lies */
+        maxY: number;
+    }
+
+    interface OutputOptions {
+        /** Force format output, otherwise attempt to use input format (optional, default true) */
+        force?: boolean | undefined;
+    }
+
+    interface JpegOptions extends OutputOptions {
+        /** Quality, integer 1-100 (optional, default 80) */
+        quality?: number | undefined;
+        /** Use progressive (interlace) scan (optional, default false) */
+        progressive?: boolean | undefined;
+        /** Set to '4:4:4' to prevent chroma subsampling when quality <= 90 (optional, default '4:2:0') */
+        chromaSubsampling?: string | undefined;
+        /** Apply trellis quantisation (optional, default  false) */
+        trellisQuantisation?: boolean | undefined;
+        /** Apply overshoot deringing (optional, default  false) */
+        overshootDeringing?: boolean | undefined;
+        /** Optimise progressive scans, forces progressive (optional, default false) */
+        optimiseScans?: boolean | undefined;
+        /** Alternative spelling of optimiseScans (optional, default false) */
+        optimizeScans?: boolean | undefined;
+        /** Optimise Huffman coding tables (optional, default true) */
+        optimiseCoding?: boolean | undefined;
+        /** Alternative spelling of optimiseCoding (optional, default true) */
+        optimizeCoding?: boolean | undefined;
+        /** Quantization table to use, integer 0-8 (optional, default 0) */
+        quantisationTable?: number | undefined;
+        /** Alternative spelling of quantisationTable (optional, default 0) */
+        quantizationTable?: number | undefined;
+        /** Use mozjpeg defaults (optional, default false) */
+        mozjpeg?: boolean | undefined;
+    }
+
+    interface Jp2Options extends OutputOptions {
+        /** Quality, integer 1-100 (optional, default 80) */
+        quality?: number;
+        /** Use lossless compression mode (optional, default false) */
+        lossless?: boolean;
+        /** Horizontal tile size (optional, default 512) */
+        tileWidth?: number;
+        /** Vertical tile size (optional, default 512) */
+        tileHeight?: number;
+        /** Set to '4:2:0' to enable chroma subsampling (optional, default '4:4:4') */
+        chromaSubsampling?: '4:4:4' | '4:2:0';
+    }
+
+    interface JxlOptions extends OutputOptions {
+        /** Maximum encoding error, between 0 (highest quality) and 15 (lowest quality) (optional, default 1.0) */
+        distance?: number;
+        /** Calculate distance based on JPEG-like quality, between 1 and 100, overrides distance if specified */
+        quality?: number;
+        /** Target decode speed tier, between 0 (highest quality) and 4 (lowest quality) (optional, default 0) */
+        decodingTier?: number;
+        /** Use lossless compression (optional, default false) */
+        lossless?: boolean;
+        /** CPU effort, between 3 (fastest) and 9 (slowest) (optional, default 7) */
+        effort?: number | undefined;
+    }
+
+    interface WebpOptions extends OutputOptions, AnimationOptions {
+        /** Quality, integer 1-100 (optional, default 80) */
+        quality?: number | undefined;
+        /** Quality of alpha layer, number from 0-100 (optional, default 100) */
+        alphaQuality?: number | undefined;
+        /** Use lossless compression mode (optional, default false) */
+        lossless?: boolean | undefined;
+        /** Use near_lossless compression mode (optional, default false) */
+        nearLossless?: boolean | undefined;
+        /** Use high quality chroma subsampling (optional, default false) */
+        smartSubsample?: boolean | undefined;
+        /** Level of CPU effort to reduce file size, integer 0-6 (optional, default 4) */
+        effort?: number | undefined;
+        /** Prevent use of animation key frames to minimise file size (slow) (optional, default false) */
+        minSize?: number;
+        /** Allow mixture of lossy and lossless animation frames (slow) (optional, default false) */
+        mixed?: boolean;
+    }
+
+    interface AvifOptions extends OutputOptions {
+        /** quality, integer 1-100 (optional, default 50) */
+        quality?: number | undefined;
+        /** use lossless compression (optional, default false) */
+        lossless?: boolean | undefined;
+        /** Level of CPU effort to reduce file size, between 0 (fastest) and 9 (slowest) (optional, default 4) */
+        effort?: number | undefined;
+        /** set to '4:2:0' to use chroma subsampling, requires libvips v8.11.0 (optional, default '4:4:4') */
+        chromaSubsampling?: string | undefined;
+    }
+
+    interface HeifOptions extends OutputOptions {
+        /** quality, integer 1-100 (optional, default 50) */
+        quality?: number | undefined;
+        /** compression format: av1, hevc (optional, default 'av1') */
+        compression?: 'av1' | 'hevc' | undefined;
+        /** use lossless compression (optional, default false) */
+        lossless?: boolean | undefined;
+        /** Level of CPU effort to reduce file size, between 0 (fastest) and 9 (slowest) (optional, default 4) */
+        effort?: number | undefined;
+        /** set to '4:2:0' to use chroma subsampling (optional, default '4:4:4') */
+        chromaSubsampling?: string | undefined;
+    }
+
+    interface GifOptions extends OutputOptions, AnimationOptions {
+        /** Always generate new palettes (slow), re-use existing by default (optional, default false) */
+        reoptimise?: boolean | undefined;
+        /** Alternative spelling of "reoptimise" (optional, default false) */
+        reoptimize?: boolean | undefined;
+        /** Maximum number of palette entries, including transparency, between 2 and 256 (optional, default 256) */
+        colours?: number | undefined;
+        /** Alternative spelling of "colours". Maximum number of palette entries, including transparency, between 2 and 256 (optional, default 256) */
+        colors?: number | undefined;
+        /** Level of CPU effort to reduce file size, between 1 (fastest) and 10 (slowest) (optional, default 7) */
+        effort?: number | undefined;
+        /** Level of Floyd-Steinberg error diffusion, between 0 (least) and 1 (most) (optional, default 1.0) */
+        dither?: number | undefined;
+        /** Maximum inter-frame error for transparency, between 0 (lossless) and 32 (optional, default 0) */
+        interFrameMaxError?: number;
+        /** Maximum inter-palette error for palette reuse, between 0 and 256 (optional, default 3) */
+        interPaletteMaxError?: number;
+    }
+
+    interface TiffOptions extends OutputOptions {
+        /** Quality, integer 1-100 (optional, default 80) */
+        quality?: number | undefined;
+        /** Compression options: none, jpeg, deflate, packbits, ccittfax4, lzw, webp, zstd, jp2k (optional, default 'jpeg') */
+        compression?: string | undefined;
+        /** Compression predictor options: none, horizontal, float (optional, default 'horizontal') */
+        predictor?: string | undefined;
+        /** Write an image pyramid (optional, default false) */
+        pyramid?: boolean | undefined;
+        /** Write a tiled tiff (optional, default false) */
+        tile?: boolean | undefined;
+        /** Horizontal tile size (optional, default 256) */
+        tileWidth?: number | undefined;
+        /** Vertical tile size (optional, default 256) */
+        tileHeight?: number | undefined;
+        /** Horizontal resolution in pixels/mm (optional, default 1.0) */
+        xres?: number | undefined;
+        /** Vertical resolution in pixels/mm (optional, default 1.0) */
+        yres?: number | undefined;
+        /** Reduce bitdepth to 1, 2 or 4 bit (optional, default 8) */
+        bitdepth?: 1 | 2 | 4 | 8 | undefined;
+        /** Resolution unit options: inch, cm (optional, default 'inch') */
+        resolutionUnit?: 'inch' | 'cm' | undefined;
+    }
+
+    interface PngOptions extends OutputOptions {
+        /** Use progressive (interlace) scan (optional, default false) */
+        progressive?: boolean | undefined;
+        /** zlib compression level, 0-9 (optional, default 6) */
+        compressionLevel?: number | undefined;
+        /** Use adaptive row filtering (optional, default false) */
+        adaptiveFiltering?: boolean | undefined;
+        /** Use the lowest number of colours needed to achieve given quality (optional, default `100`) */
+        quality?: number | undefined;
+        /** Level of CPU effort to reduce file size, between 1 (fastest) and 10 (slowest), sets palette to true (optional, default 7) */
+        effort?: number | undefined;
+        /** Quantise to a palette-based image with alpha transparency support (optional, default false) */
+        palette?: boolean | undefined;
+        /** Maximum number of palette entries (optional, default 256) */
+        colours?: number | undefined;
+        /** Alternative Spelling of "colours". Maximum number of palette entries (optional, default 256) */
+        colors?: number | undefined;
+        /**  Level of Floyd-Steinberg error diffusion (optional, default 1.0) */
+        dither?: number | undefined;
+    }
+
+    interface RotateOptions {
+        /** parsed by the color module to extract values for red, green, blue and alpha. (optional, default "#000000") */
+        background?: Color | undefined;
+    }
+
+    interface FlattenOptions {
+        /** background colour, parsed by the color module, defaults to black. (optional, default {r:0,g:0,b:0}) */
+        background?: Color | undefined;
+    }
+
+    interface NegateOptions {
+        /** whether or not to negate any alpha channel. (optional, default true) */
+        alpha?: boolean | undefined;
+    }
+
+    interface ResizeOptions {
+        /** Alternative means of specifying width. If both are present this takes priority. */
+        width?: number | undefined;
+        /** Alternative means of specifying height. If both are present this takes priority. */
+        height?: number | undefined;
+        /** How the image should be resized to fit both provided dimensions, one of cover, contain, fill, inside or outside. (optional, default 'cover') */
+        fit?: keyof FitEnum | undefined;
+        /** Position, gravity or strategy to use when fit is cover or contain. (optional, default 'centre') */
+        position?: number | string | undefined;
+        /** Background colour when using a fit of contain, parsed by the color module, defaults to black without transparency. (optional, default {r:0,g:0,b:0,alpha:1}) */
+        background?: Color | undefined;
+        /** The kernel to use for image reduction. (optional, default 'lanczos3') */
+        kernel?: keyof KernelEnum | undefined;
+        /** Do not enlarge if the width or height are already less than the specified dimensions, equivalent to GraphicsMagick's > geometry option. (optional, default false) */
+        withoutEnlargement?: boolean | undefined;
+        /** Do not reduce if the width or height are already greater than the specified dimensions, equivalent to GraphicsMagick's < geometry option. (optional, default false) */
+        withoutReduction?: boolean | undefined;
+        /** Take greater advantage of the JPEG and WebP shrink-on-load feature, which can lead to a slight moiré pattern on some images. (optional, default true) */
+        fastShrinkOnLoad?: boolean | undefined;
+    }
+
+    interface Region {
+        /** zero-indexed offset from left edge */
+        left: number;
+        /** zero-indexed offset from top edge */
+        top: number;
+        /** dimension of extracted image */
+        width: number;
+        /** dimension of extracted image */
+        height: number;
+    }
+
+    interface Noise {
+        /** type of generated noise, currently only gaussian is supported. */
+        type?: 'gaussian' | undefined;
+        /** mean of pixels in generated noise. */
+        mean?: number | undefined;
+        /** standard deviation of pixels in generated noise. */
+        sigma?: number | undefined;
+    }
+
+    interface ExtendOptions {
+        /** single pixel count to top edge (optional, default 0) */
+        top?: number | undefined;
+        /** single pixel count to left edge (optional, default 0) */
+        left?: number | undefined;
+        /** single pixel count to bottom edge (optional, default 0) */
+        bottom?: number | undefined;
+        /** single pixel count to right edge (optional, default 0) */
+        right?: number | undefined;
+        /** background colour, parsed by the color module, defaults to black without transparency. (optional, default {r:0,g:0,b:0,alpha:1}) */
+        background?: Color | undefined;
+    }
+
+    interface TrimOptions {
+        /** background colour, parsed by the color module, defaults to that of the top-left pixel. (optional) */
+        background?: Color | undefined;
+        /** the allowed difference from the above colour, a positive number. (optional, default `10`) */
+        threshold?: number | undefined;
+    }
+
+    interface RawOptions {
+        depth?: 'char' | 'uchar' | 'short' | 'ushort' | 'int' | 'uint' | 'float' | 'complex' | 'double' | 'dpcomplex';
+    }
+
+    /** 3 for sRGB, 4 for CMYK */
+    type Channels = 3 | 4;
+
+    interface RGBA {
+        r?: number | undefined;
+        g?: number | undefined;
+        b?: number | undefined;
+        alpha?: number | undefined;
+    }
+
+    type Color = string | RGBA;
+
+    interface Kernel {
+        /** width of the kernel in pixels. */
+        width: number;
+        /** height of the kernel in pixels. */
+        height: number;
+        /** Array of length width*height containing the kernel values. */
+        kernel: ArrayLike<number>;
+        /** the scale of the kernel in pixels. (optional, default sum) */
+        scale?: number | undefined;
+        /** the offset of the kernel in pixels. (optional, default 0) */
+        offset?: number | undefined;
+    }
+
+    interface ClaheOptions {
+        /** width of the region */
+        width: number;
+        /** height of the region */
+        height: number;
+        /** max slope of the cumulative contrast. A value of 0 disables contrast limiting. Valid values are integers in the range 0-100 (inclusive) (optional, default 3) */
+        maxSlope?: number | undefined;
+    }
+
+    interface ThresholdOptions {
+        /** convert to single channel greyscale. (optional, default true) */
+        greyscale?: boolean | undefined;
+        /** alternative spelling for greyscale. (optional, default true) */
+        grayscale?: boolean | undefined;
+    }
+
+    interface OverlayOptions {
+        /** Buffer containing image data, String containing the path to an image file, or Create object  */
+        input?: string | Buffer | { create: Create } | { text: CreateText } | undefined;
+        /** how to blend this image with the image below. (optional, default `'over'`) */
+        blend?: Blend | undefined;
+        /** gravity at which to place the overlay. (optional, default 'centre') */
+        gravity?: Gravity | undefined;
+        /** the pixel offset from the top edge. */
+        top?: number | undefined;
+        /** the pixel offset from the left edge. */
+        left?: number | undefined;
+        /** set to true to repeat the overlay image across the entire image with the given  gravity. (optional, default false) */
+        tile?: boolean | undefined;
+        /** number representing the DPI for vector overlay image. (optional, default 72) */
+        density?: number | undefined;
+        /** describes overlay when using raw pixel data. */
+        raw?: Raw | undefined;
+        /** Set to true to avoid premultipling the image below. Equivalent to the --premultiplied vips option. */
+        premultiplied?: boolean | undefined;
+        /** Set to true to read all frames/pages of an animated image. (optional, default false). */
+        animated?: boolean | undefined;
+        /**
+         *  When to abort processing of invalid pixel data, one of (in order of sensitivity):
+         *  'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels, invalid metadata will always abort. (optional, default 'warning')
+         */
+        failOn?: FailOnOptions | undefined;
+        /**
+         * Do not process input images where the number of pixels (width x height) exceeds this limit.
+         * Assumes image dimensions contained in the input metadata can be trusted.
+         * An integral Number of pixels, zero or false to remove limit, true to use default limit of 268402689 (0x3FFF x 0x3FFF). (optional, default 268402689)
+         */
+        limitInputPixels?: number | boolean | undefined;
+    }
+
+    interface TileOptions {
+        /** Tile size in pixels, a value between 1 and 8192. (optional, default 256) */
+        size?: number | undefined;
+        /** Tile overlap in pixels, a value between 0 and 8192. (optional, default 0) */
+        overlap?: number | undefined;
+        /** Tile angle of rotation, must be a multiple of 90. (optional, default 0) */
+        angle?: number | undefined;
+        /** background colour, parsed by the color module, defaults to white without transparency. (optional, default {r:255,g:255,b:255,alpha:1}) */
+        background?: string | RGBA | undefined;
+        /** How deep to make the pyramid, possible values are "onepixel", "onetile" or "one" (default based on layout) */
+        depth?: string | undefined;
+        /** Threshold to skip tile generation, a value 0 - 255 for 8-bit images or 0 - 65535 for 16-bit images */
+        skipBlanks?: number | undefined;
+        /** Tile container, with value fs (filesystem) or zip (compressed file). (optional, default 'fs') */
+        container?: TileContainer | undefined;
+        /** Filesystem layout, possible values are dz, iiif, iiif3, zoomify or google. (optional, default 'dz') */
+        layout?: TileLayout | undefined;
+        /** Centre image in tile. (optional, default false) */
+        centre?: boolean | undefined;
+        /** Alternative spelling of centre. (optional, default false) */
+        center?: boolean | undefined;
+        /** When layout is iiif/iiif3, sets the @id/id attribute of info.json (optional, default 'https://example.com/iiif') */
+        id?: string | undefined;
+        /** The name of the directory within the zip file when container is `zip`. */
+        basename?: string | undefined;
+    }
+
+    interface AnimationOptions {
+        /** Number of animation iterations, a value between 0 and 65535. Use 0 for infinite animation. (optional, default 0) */
+        loop?: number | undefined;
+        /** delay(s) between animation frames (in milliseconds), each value between 0 and 65535. (optional) */
+        delay?: number | number[] | undefined;
+    }
+
+    interface SharpenOptions {
+        /** The sigma of the Gaussian mask, where sigma = 1 + radius / 2, between 0.000001 and 10000 */
+        sigma: number;
+        /** The level of sharpening to apply to "flat" areas, between 0 and 1000000 (optional, default 1.0) */
+        m1?: number | undefined;
+        /** The level of sharpening to apply to "jagged" areas, between 0 and 1000000 (optional, default 2.0) */
+        m2?: number | undefined;
+        /** Threshold between "flat" and "jagged", between 0 and 1000000 (optional, default 2.0) */
+        x1?: number | undefined;
+        /** Maximum amount of brightening, between 0 and 1000000 (optional, default 10.0) */
+        y2?: number | undefined;
+        /** Maximum amount of darkening, between 0 and 1000000 (optional, default 20.0) */
+        y3?: number | undefined;
+    }
+
+    interface AffineOptions {
+        /** Parsed by the color module to extract values for red, green, blue and alpha. (optional, default "#000000") */
+        background?: string | object | undefined;
+        /** Input horizontal offset (optional, default 0) */
+        idx?: number | undefined;
+        /** Input vertical offset (optional, default 0) */
+        idy?: number | undefined;
+        /** Output horizontal offset (optional, default 0) */
+        odx?: number | undefined;
+        /** Output horizontal offset (optional, default 0) */
+        ody?: number | undefined;
+        /** Interpolator (optional, default sharp.interpolators.bicubic) */
+        interpolator?: Interpolators[keyof Interpolators] | undefined;
+    }
+
+    interface OutputInfo {
+        format: string;
+        size: number;
+        width: number;
+        height: number;
+        channels: 1 | 2 | 3 | 4;
+        /** indicating if premultiplication was used */
+        premultiplied: boolean;
+        /** Only defined when using a crop strategy */
+        cropOffsetLeft?: number | undefined;
+        /** Only defined when using a crop strategy */
+        cropOffsetTop?: number | undefined;
+        /** Only defined when using a trim method */
+        trimOffsetLeft?: number | undefined;
+        /** Only defined when using a trim method */
+        trimOffsetTop?: number | undefined;
+        /** DPI the font was rendered at, only defined when using `text` input */
+        textAutofitDpi?: number | undefined;
+    }
+
+    interface AvailableFormatInfo {
+        id: string;
+        input: { file: boolean; buffer: boolean; stream: boolean; fileSuffix?: string[] };
+        output: { file: boolean; buffer: boolean; stream: boolean; alias?: string[] };
+    }
+
+    interface FitEnum {
+        contain: 'contain';
+        cover: 'cover';
+        fill: 'fill';
+        inside: 'inside';
+        outside: 'outside';
+    }
+
+    interface KernelEnum {
+        nearest: 'nearest';
+        cubic: 'cubic';
+        mitchell: 'mitchell';
+        lanczos2: 'lanczos2';
+        lanczos3: 'lanczos3';
+    }
+
+    interface BoolEnum {
+        and: 'and';
+        or: 'or';
+        eor: 'eor';
+    }
+
+    interface ColourspaceEnum {
+        multiband: string;
+        'b-w': string;
+        bw: string;
+        cmyk: string;
+        srgb: string;
+    }
+
+    type FailOnOptions = 'none' | 'truncated' | 'error' | 'warning';
+
+    type TextAlign = 'left' | 'centre' | 'center' | 'right';
+
+    type TileContainer = 'fs' | 'zip';
+
+    type TileLayout = 'dz' | 'iiif' | 'iiif3' | 'zoomify' | 'google';
+
+    type Blend =
+        | 'clear'
+        | 'source'
+        | 'over'
+        | 'in'
+        | 'out'
+        | 'atop'
+        | 'dest'
+        | 'dest-over'
+        | 'dest-in'
+        | 'dest-out'
+        | 'dest-atop'
+        | 'xor'
+        | 'add'
+        | 'saturate'
+        | 'multiply'
+        | 'screen'
+        | 'overlay'
+        | 'darken'
+        | 'lighten'
+        | 'color-dodge'
+        | 'colour-dodge'
+        | 'color-burn'
+        | 'colour-burn'
+        | 'hard-light'
+        | 'soft-light'
+        | 'difference'
+        | 'exclusion';
+
+    type Gravity = number | string;
+
+    interface GravityEnum {
+        north: number;
+        northeast: number;
+        southeast: number;
+        south: number;
+        southwest: number;
+        west: number;
+        northwest: number;
+        east: number;
+        center: number;
+        centre: number;
+    }
+
+    interface StrategyEnum {
+        entropy: number;
+        attention: number;
+    }
+
+    interface FormatEnum {
+        avif: AvailableFormatInfo;
+        dz: AvailableFormatInfo;
+        fits: AvailableFormatInfo;
+        gif: AvailableFormatInfo;
+        heif: AvailableFormatInfo;
+        input: AvailableFormatInfo;
+        jpeg: AvailableFormatInfo;
+        jpg: AvailableFormatInfo;
+        jp2: AvailableFormatInfo;
+        jxl: AvailableFormatInfo;
+        magick: AvailableFormatInfo;
+        openslide: AvailableFormatInfo;
+        pdf: AvailableFormatInfo;
+        png: AvailableFormatInfo;
+        ppm: AvailableFormatInfo;
+        raw: AvailableFormatInfo;
+        svg: AvailableFormatInfo;
+        tiff: AvailableFormatInfo;
+        tif: AvailableFormatInfo;
+        v: AvailableFormatInfo;
+        webp: AvailableFormatInfo;
+    }
+
+    interface CacheResult {
+        memory: { current: number; high: number; max: number };
+        files: { current: number; max: number };
+        items: { current: number; max: number };
+    }
+
+    interface Interpolators {
+        /** [Nearest neighbour interpolation](http://en.wikipedia.org/wiki/Nearest-neighbor_interpolation). Suitable for image enlargement only. */
+        nearest: 'nearest';
+        /** [Bilinear interpolation](http://en.wikipedia.org/wiki/Bilinear_interpolation). Faster than bicubic but with less smooth results. */
+        bilinear: 'bilinear';
+        /** [Bicubic interpolation](http://en.wikipedia.org/wiki/Bicubic_interpolation) (the default). */
+        bicubic: 'bicubic';
+        /**
+         * [LBB interpolation](https://github.com/libvips/libvips/blob/master/libvips/resample/lbb.cpp#L100).
+         * Prevents some "[acutance](http://en.wikipedia.org/wiki/Acutance)" but typically reduces performance by a factor of 2.
+         */
+        locallyBoundedBicubic: 'lbb';
+        /** [Nohalo interpolation](http://eprints.soton.ac.uk/268086/). Prevents acutance but typically reduces performance by a factor of 3. */
+        nohalo: 'nohalo';
+        /** [VSQBS interpolation](https://github.com/libvips/libvips/blob/master/libvips/resample/vsqbs.cpp#L48). Prevents "staircasing" when enlarging. */
+        vertexSplitQuadraticBasisSpline: 'vsqbs';
+    }
+
+    type Matrix2x2 = [[number, number], [number, number]];
+    type Matrix3x3 = [[number, number, number], [number, number, number], [number, number, number]];
+}
+
+export = sharp;

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "tunnel-agent": "^0.6.0"
   },
   "devDependencies": {
+    "@types/node": "*",
     "async": "^3.2.4",
     "cc": "^3.0.1",
     "exif-reader": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -90,16 +90,18 @@
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node install/can-compile && node-gyp rebuild && node install/dll-copy)",
     "clean": "rm -rf node_modules/ build/ vendor/ .nyc_output/ coverage/ test/fixtures/output.*",
-    "test": "npm run test-lint && npm run test-unit && npm run test-licensing",
+    "test": "npm run test-lint && npm run test-unit && npm run test-licensing && npm run test-types",
     "test-lint": "semistandard && cpplint",
     "test-unit": "nyc --reporter=lcov --reporter=text --check-coverage --branches=100 mocha",
     "test-licensing": "license-checker --production --summary --onlyAllow=\"Apache-2.0;BSD;ISC;MIT\"",
     "test-leak": "./test/leak/leak.sh",
+    "test-types": "tsd",
     "docs-build": "node docs/build && node docs/search-index/build",
     "docs-serve": "cd docs && npx serve",
     "docs-publish": "cd docs && npx firebase-tools deploy --project pixelplumbing --only hosting:pixelplumbing-sharp"
   },
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "binding.gyp",
     "install/**",
@@ -152,7 +154,8 @@
     "nyc": "^15.1.0",
     "prebuild": "^11.0.4",
     "rimraf": "^3.0.2",
-    "semistandard": "^16.0.1"
+    "semistandard": "^16.0.1",
+    "tsd": "^0.24.1"
   },
   "license": "Apache-2.0",
   "config": {
@@ -194,5 +197,8 @@
     "filter": [
       "build/include"
     ]
+  },
+  "tsd": {
+    "directory": "test/types/"
   }
 }

--- a/test/types/sharp.test-d.ts
+++ b/test/types/sharp.test-d.ts
@@ -1,0 +1,636 @@
+import sharp = require('../../');
+
+import { createReadStream, createWriteStream } from 'fs';
+
+const input: Buffer = Buffer.alloc(0);
+const readableStream: NodeJS.ReadableStream = createReadStream(input);
+const writableStream: NodeJS.WritableStream = createWriteStream(input);
+
+sharp(input)
+  .extractChannel('green')
+  .toFile('input_green.jpg', (err, info) => {
+    // info.channels === 1
+    // input_green.jpg contains the green channel of the input image
+  });
+
+sharp('3-channel-rgb-input.png')
+  .bandbool(sharp.bool.and)
+  .toFile('1-channel-output.png', (err, info) => {
+    // The output will be a single channel image where each pixel `P = R & G & B`.
+    // If `I(1,1) = [247, 170, 14] = [0b11110111, 0b10101010, 0b00001111]`
+    // then `O(1,1) = 0b11110111 & 0b10101010 & 0b00001111 = 0b00000010 = 2`.
+  });
+
+sharp('input.png')
+  .rotate(180)
+  .resize(300)
+  .flatten({ background: '#ff6600' })
+  .composite([{ input: 'overlay.png', gravity: sharp.gravity.southeast, animated: false, failOn: 'warning' }])
+  .sharpen()
+  .withMetadata()
+  .withMetadata({
+    density: 96,
+    orientation: 8,
+    icc: 'some/path',
+    exif: { IFD0: { Copyright: 'Wernham Hogg' } },
+  })
+  .webp({
+    quality: 90,
+  })
+  .toBuffer()
+  .then((outputBuffer: Buffer) => {
+    // outputBuffer contains upside down, 300px wide, alpha channel flattened
+    // onto orange background, composited with overlay.png with SE gravity,
+    // sharpened, with metadata, 90% quality WebP image data. Phew!
+  });
+
+sharp('input.jpg')
+  .resize(300, 200)
+  .toFile('output.jpg', (err: Error) => {
+    // output.jpg is a 300 pixels wide and 200 pixels high image
+    // containing a scaled and cropped version of input.jpg
+  });
+
+sharp('input.jpg').resize({ width: 300 }).blur(false).blur(true).toFile('output.jpg');
+
+sharp({
+  create: {
+    width: 300,
+    height: 200,
+    channels: 4,
+    background: { r: 255, g: 0, b: 0, alpha: 128 },
+  },
+})
+  .png()
+  .toBuffer();
+
+let transformer = sharp()
+  .resize(300)
+  .on('info', (info: sharp.OutputInfo) => {
+    console.log('Image height is ' + info.height);
+  });
+readableStream.pipe(transformer).pipe(writableStream);
+
+console.log(sharp.format);
+console.log(sharp.versions);
+console.log(sharp.vendor.current);
+console.log(sharp.vendor.installed.join(', '));
+
+sharp.queue.on('change', (queueLength: number) => {
+  console.log(`Queue contains ${queueLength} task(s)`);
+});
+
+let pipeline: sharp.Sharp = sharp().rotate();
+pipeline.clone().resize(800, 600).pipe(writableStream);
+pipeline.clone().extract({ left: 20, top: 20, width: 100, height: 100 }).pipe(writableStream);
+readableStream.pipe(pipeline);
+// firstWritableStream receives auto-rotated, resized readableStream
+// secondWritableStream receives auto-rotated, extracted region of readableStream
+
+const image: sharp.Sharp = sharp(input);
+image
+  .metadata()
+  .then<Buffer | undefined>((metadata: sharp.Metadata) => {
+    if (metadata.width) {
+      return image
+        .resize(Math.round(metadata.width / 2))
+        .webp()
+        .toBuffer();
+    }
+  })
+  .then((data) => {
+    // data contains a WebP image half the width and height of the original JPEG
+  });
+
+pipeline = sharp()
+  .rotate()
+  .resize(undefined, 200)
+  .toBuffer((err: Error, outputBuffer: Buffer, info: sharp.OutputInfo) => {
+    // outputBuffer contains 200px high JPEG image data,
+    // auto-rotated using EXIF Orientation tag
+    // info.width and info.height contain the dimensions of the resized image
+  });
+readableStream.pipe(pipeline);
+
+sharp(input)
+  .extract({ left: 0, top: 0, width: 100, height: 100 })
+  .toFile('output', (err: Error) => {
+    // Extract a region of the input image, saving in the same format.
+  });
+
+sharp(input)
+  .extract({ left: 0, top: 0, width: 100, height: 100 })
+  .resize(200, 200)
+  .extract({ left: 0, top: 0, width: 100, height: 100 })
+  .toFile('output', (err: Error) => {
+    // Extract a region, resize, then extract from the resized image
+  });
+
+// Resize to 140 pixels wide, then add 10 transparent pixels
+// to the top, left and right edges and 20 to the bottom edge
+sharp(input)
+  .resize(140, null, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+  .extend({ top: 10, bottom: 20, left: 10, right: 10 });
+
+sharp(input)
+  .convolve({
+    width: 3,
+    height: 3,
+    kernel: [-1, 0, 1, -2, 0, 2, -1, 0, 1],
+  })
+  .raw()
+  .toBuffer((err: Error, data: Buffer, info: sharp.OutputInfo) => {
+    // data contains the raw pixel data representing the convolution
+    // of the input image with the horizontal Sobel operator
+  });
+
+sharp('input.tiff')
+  .png()
+  .tile({
+    size: 512,
+  })
+  .toFile('output.dz', (err: Error, info: sharp.OutputInfo) => {
+    // output.dzi is the Deep Zoom XML definition
+    // output_files contains 512x512 tiles grouped by zoom level
+  });
+
+sharp('input.tiff')
+  .png()
+  .tile({
+    size: 512,
+    center: true,
+    layout: 'iiif3',
+    id: 'https://my.image.host/iiif',
+  })
+  .toFile('output');
+
+sharp(input)
+  .resize(200, 300, {
+    fit: 'contain',
+    position: 'north',
+    kernel: sharp.kernel.lanczos2,
+    background: 'white',
+  })
+  .toFile('output.tiff')
+  .then(() => {
+    // output.tiff is a 200 pixels wide and 300 pixels high image
+    // containing a lanczos2/nohalo scaled version, embedded on a white canvas,
+    // of the image data in inputBuffer
+  });
+
+transformer = sharp()
+  .resize(200, 200, {
+    fit: 'cover',
+    position: sharp.strategy.entropy,
+  })
+  .on('error', (err: Error) => {
+    console.log(err);
+  });
+// Read image data from readableStream
+// Write 200px square auto-cropped image data to writableStream
+readableStream.pipe(transformer).pipe(writableStream);
+
+sharp('input.gif')
+  .resize(200, 300, {
+    fit: 'contain',
+    position: 'north',
+    background: { r: 0, g: 0, b: 0, alpha: 0 },
+  })
+  .toFormat(sharp.format.webp)
+  .toBuffer((err: Error, outputBuffer: Buffer) => {
+    if (err) {
+      throw err;
+    }
+    // outputBuffer contains WebP image data of a 200 pixels wide and 300 pixels high
+    // containing a scaled version, embedded on a transparent canvas, of input.gif
+  });
+
+sharp(input)
+  .resize(200, 200, { fit: 'inside' })
+  .toFormat('jpeg')
+  .toBuffer()
+  .then((outputBuffer: Buffer) => {
+    // outputBuffer contains JPEG image data no wider than 200 pixels and no higher
+    // than 200 pixels regardless of the inputBuffer image dimensions
+  });
+
+sharp(input)
+  .resize(100, 100)
+  .toFormat('jpg')
+  .toBuffer({ resolveWithObject: false })
+  .then((outputBuffer: Buffer) => {
+    // Resolves with a Buffer object when resolveWithObject is false
+  });
+
+sharp(input)
+  .resize(100, 100)
+  .toBuffer({ resolveWithObject: true })
+  .then((object: { data: Buffer; info: sharp.OutputInfo }) => {
+    // Resolve with an object containing data Buffer and an OutputInfo object
+    // when resolveWithObject is true
+  });
+
+sharp(input)
+  .resize(640, 480, { withoutEnlargement: true })
+  .toFormat('jpeg')
+  .toBuffer()
+  .then((outputBuffer: Buffer) => {
+    // outputBuffer contains JPEG image data no larger than the input
+  });
+
+sharp(input)
+  .resize(640, 480, { withoutReduction: true })
+  .toFormat('jpeg')
+  .toBuffer()
+  .then((outputBuffer: Buffer) => {
+    // outputBuffer contains JPEG image data no smaller than the input
+  });
+
+// Output to tif
+sharp(input)
+  .resize(100, 100)
+  .toFormat('tif')
+  .toFormat('tiff')
+  .toFormat(sharp.format.tif)
+  .toFormat(sharp.format.tiff)
+  .toBuffer();
+
+const stats = sharp.cache();
+
+sharp.cache({ items: 200 });
+sharp.cache({ files: 0 });
+sharp.cache(false);
+
+const threads = sharp.concurrency(); // 4
+sharp.concurrency(2); // 2
+sharp.concurrency(0); // 4
+
+const counters = sharp.counters(); // { queue: 2, process: 4 }
+
+let simd: boolean = sharp.simd();
+// simd is `true` if SIMD is currently enabled
+
+simd = sharp.simd(true);
+// attempts to enable the use of SIMD, returning true if available
+
+const vipsVersion: string = sharp.versions.vips;
+
+if (sharp.versions.cairo) {
+  const cairoVersion: string = sharp.versions.cairo;
+}
+
+sharp('input.gif')
+  .linear(1)
+  .linear(1, 0)
+  .linear(null, 0)
+  .linear([0.25, 0.5, 0.75], [150, 100, 50])
+
+  .recomb([
+    [0.3588, 0.7044, 0.1368],
+    [0.299, 0.587, 0.114],
+    [0.2392, 0.4696, 0.0912],
+  ])
+
+  .modulate({ brightness: 2 })
+  .modulate({ hue: 180 })
+  .modulate({ lightness: 10 })
+  .modulate({ brightness: 0.5, saturation: 0.5, hue: 90 });
+
+// From https://sharp.pixelplumbing.com/api-output#examples-9
+// Extract raw RGB pixel data from JPEG input
+sharp('input.jpg')
+  .raw()
+  .toBuffer({ resolveWithObject: true })
+  .then(({ data, info }) => {
+    console.log(data);
+    console.log(info);
+  });
+
+sharp(input).jpeg().jpeg({}).jpeg({
+  progressive: false,
+  chromaSubsampling: '4:4:4',
+  trellisQuantisation: false,
+  overshootDeringing: false,
+  optimiseScans: false,
+  optimizeScans: false,
+  optimiseCoding: false,
+  optimizeCoding: false,
+  quantisationTable: 10,
+  quantizationTable: 10,
+  mozjpeg: false,
+  quality: 10,
+  force: false,
+});
+
+sharp(input).png().png({}).png({
+  progressive: false,
+  compressionLevel: 10,
+  adaptiveFiltering: false,
+  force: false,
+  quality: 10,
+  palette: false,
+  colours: 10,
+  colors: 10,
+  dither: 10,
+});
+
+sharp(input)
+  .avif()
+  .avif({})
+  .avif({ quality: 50, lossless: false, effort: 5, chromaSubsampling: '4:2:0' })
+  .heif()
+  .heif({})
+  .heif({ quality: 50, compression: 'hevc', lossless: false, effort: 5, chromaSubsampling: '4:2:0' })
+  .toBuffer({ resolveWithObject: true })
+  .then(({ data, info }) => {
+    console.log(data);
+    console.log(info);
+  });
+
+sharp(input)
+  .gif()
+  .gif({})
+  .gif({ loop: 0, delay: [], force: true })
+  .gif({ delay: 30 })
+  .gif({ reoptimise: true })
+  .gif({ reoptimize: false })
+  .toBuffer({ resolveWithObject: true })
+  .then(({ data, info }) => {
+    console.log(data);
+    console.log(info);
+  });
+
+sharp(input)
+  .tiff({ compression: 'packbits' })
+  .toBuffer({ resolveWithObject: true })
+  .then(({ data, info }) => {
+    console.log(data);
+    console.log(info);
+  });
+
+sharp('input.jpg')
+  .stats()
+  .then(stats => {
+    const {
+      sharpness,
+      dominant: { r, g, b },
+    } = stats;
+    console.log(sharpness);
+    console.log(`${r}, ${g}, ${b}`);
+  });
+
+// From https://sharp.pixelplumbing.com/api-output#examples-9
+// Extract alpha channel as raw pixel data from PNG input
+sharp('input.png').ensureAlpha().ensureAlpha(0).extractChannel(3).toColourspace('b-w').raw().toBuffer();
+
+// From https://sharp.pixelplumbing.com/api-constructor#examples-4
+// Convert an animated GIF to an animated WebP
+sharp('in.gif', { animated: true }).toFile('out.webp');
+
+// From https://github.com/lovell/sharp/issues/2701
+// Type support for limitInputPixels
+sharp({
+  create: {
+    background: 'red',
+    channels: 4,
+    height: 25000,
+    width: 25000,
+  },
+  limitInputPixels: false,
+})
+  .toFormat('png')
+  .toBuffer()
+  .then(largeImage => sharp(input).composite([{ input: largeImage, limitInputPixels: false }]));
+
+// Taken from API documentation at
+// https://sharp.pixelplumbing.com/api-operation#clahe
+// introducted
+sharp('input.jpg').clahe({ width: 10, height: 10 }).toFile('output.jpg');
+
+sharp('input.jpg').clahe({ width: 10, height: 10, maxSlope: 5 }).toFile('outfile.jpg');
+
+// Support `unlimited` input option
+sharp('input.png', { unlimited: true }).resize(320, 240).toFile('outfile.png');
+
+// Support `subifd` input option for tiffs
+sharp('input.tiff', { subifd: 3 }).resize(320, 240).toFile('outfile.png');
+
+// Support creating with noise
+sharp({
+  create: {
+    background: 'red',
+    channels: 4,
+    height: 100,
+    width: 100,
+    noise: {
+      type: 'gaussian',
+      mean: 128,
+      sigma: 30,
+    },
+  },
+})
+  .png()
+  .toFile('output.png');
+
+sharp(new Uint8Array(input.buffer)).toFile('output.jpg');
+
+// Support for negate options
+sharp('input.png').negate({ alpha: false }).toFile('output.png');
+
+// From https://github.com/lovell/sharp/pull/2704
+// Type support for pipelineColourspace
+sharp(input)
+  .pipelineColourspace('rgb16')
+  .resize(320, 240)
+  .gamma()
+  .toColourspace('srgb') // this is the default, but included here for clarity
+  .toBuffer();
+
+// From https://github.com/lovell/sharp/pull/1439
+// Second parameter to gamma operation for different output gamma
+sharp(input)
+  .resize(129, 111)
+  .gamma(2.2, 3.0)
+  .toBuffer(err => {
+    if (err) throw err;
+  });
+
+// Support for raw depth specification
+sharp('16bpc.png')
+  .toColourspace('rgb16')
+  .raw({ depth: 'ushort' })
+  .toBuffer((error, data, { width, height, channels, size }) => {
+    console.log((size / width / height / channels) * 8);
+    console.log(new Uint16Array(data.buffer));
+  });
+
+// Output channels are constrained from 1-4, can be used as raw input
+sharp(input)
+  .toBuffer({ resolveWithObject: true })
+  .then(result => {
+    const newImg = sharp(result.data, {
+      raw: {
+        channels: result.info.channels,
+        width: result.info.width,
+        height: result.info.height,
+      },
+    });
+
+    return newImg.toBuffer();
+  });
+
+// Support for specifying a timeout
+sharp('someImage.png').timeout({ seconds: 30 }).resize(300, 300).toBuffer();
+
+// Support for `effort` in different formats
+sharp('input.tiff').png({ effort: 9 }).toFile('out.png');
+sharp('input.tiff').webp({ effort: 9 }).toFile('out.webp');
+sharp('input.tiff').avif({ effort: 9 }).toFile('out.avif');
+sharp('input.tiff').heif({ effort: 9 }).toFile('out.heif');
+sharp('input.tiff').gif({ effort: 9 }).toFile('out.gif');
+
+// Support for `colors`/`colours` for gif output
+sharp('input.gif').gif({ colors: 16 }).toFile('out.gif');
+sharp('input.gif').gif({ colours: 16 }).toFile('out.gif');
+
+// Support for `dither` for gif/png output
+sharp('input.gif').gif({ dither: 0.5 }).toFile('out.gif');
+sharp('input.gif').png({ dither: 0.5 }).toFile('out.png');
+
+// Support for `interFrameMaxError` for gif output
+sharp('input.gif').gif({ interFrameMaxError: 0 }).toFile('out.gif');
+
+// Support for `interPaletteMaxError` for gif output
+sharp('input.gif').gif({ interPaletteMaxError: 0 }).toFile('out.gif');
+
+// Support for `resolutionUnit` for tiff output
+sharp('input.tiff').tiff({ resolutionUnit: 'cm' }).toFile('out.tiff');
+
+// Support for `jp2` output with different options
+sharp('input.tiff').jp2().toFile('out.jp2');
+sharp('input.tiff').jp2({ quality: 50 }).toFile('out.jp2');
+sharp('input.tiff').jp2({ lossless: true }).toFile('out.jp2');
+sharp('input.tiff').jp2({ tileWidth: 128, tileHeight: 128 }).toFile('out.jp2');
+sharp('input.tiff').jp2({ chromaSubsampling: '4:2:0' }).toFile('out.jp2');
+
+// Support for `jxl` output with different options
+sharp('input.tiff').jxl().toFile('out.jxl');
+sharp('input.tiff').jxl({ distance: 15.0 }).toFile('out.jxl');
+sharp('input.tiff').jxl({ quality: 50 }).toFile('out.jxl');
+sharp('input.tiff').jxl({ decodingTier: 4 }).toFile('out.jxl');
+sharp('input.tiff').jxl({ lossless: true }).toFile('out.jxl');
+sharp('input.tiff').jxl({ effort: 7 }).toFile('out.jxl');
+
+// Support `minSize` and `mixed` webp options
+sharp('input.tiff').webp({ minSize: 1000, mixed: true }).toFile('out.gif');
+
+// 'failOn' input param
+sharp('input.tiff', { failOn: 'none' });
+sharp('input.tiff', { failOn: 'truncated' });
+sharp('input.tiff', { failOn: 'error' });
+sharp('input.tiff', { failOn: 'warning' });
+
+// Sharpen operation taking an object instead of three params
+sharp('input.tiff').sharpen().toBuffer();
+sharp('input.tiff').sharpen({ sigma: 2 }).toBuffer();
+sharp('input.tiff')
+  .sharpen({
+    sigma: 2,
+    m1: 0,
+    m2: 3,
+    x1: 3,
+    y2: 15,
+    y3: 15,
+  })
+  .toBuffer();
+
+// Affine operator + interpolator hash
+sharp().affine(
+  [
+    [1, 0.3],
+    [0.1, 0.7],
+  ],
+  {
+    background: 'white',
+    interpolator: sharp.interpolators.nohalo,
+  },
+);
+
+sharp().affine([1, 1, 1, 1], {
+  background: 'white',
+  idx: 0,
+  idy: 0,
+  odx: 0,
+  ody: 0,
+});
+
+const bicubic: string = sharp.interpolators.bicubic;
+const bilinear: string = sharp.interpolators.bilinear;
+const locallyBoundedBicubic: string = sharp.interpolators.locallyBoundedBicubic;
+const nearest: string = sharp.interpolators.nearest;
+const nohalo: string = sharp.interpolators.nohalo;
+const vertexSplitQuadraticBasisSpline: string = sharp.interpolators.vertexSplitQuadraticBasisSpline;
+
+// Triming
+sharp(input).trim('#000').toBuffer();
+sharp(input).trim(10).toBuffer();
+sharp(input).trim({ background: '#bf1942', threshold: 30 }).toBuffer();
+
+// Text input
+sharp({
+  text: {
+    text: 'Hello world',
+    align: 'centre',
+    dpi: 72,
+    font: 'Arial',
+    fontfile: 'path/to/arial.ttf',
+    height: 500,
+    width: 500,
+    rgba: true,
+    justify: true,
+    spacing: 10,
+  },
+})
+  .png()
+  .toBuffer({ resolveWithObject: true })
+  .then(out => {
+    console.log(out.info.textAutofitDpi);
+  });
+
+// Text composite
+sharp('input.png').composite([
+  {
+    input: {
+      text: {
+        text: 'Okay then',
+        font: 'Comic Sans',
+      },
+    },
+  },
+]);
+
+// From https://github.com/lovell/sharp/pull/1835
+sharp('input.png').composite([
+  {
+    input: {
+      text: {
+        text: 'Okay then',
+        font: 'Comic Sans',
+      },
+    },
+    blend: 'color-burn',
+    top: 0,
+    left: 0,
+    premultiplied: true,
+  },
+]);
+
+// https://github.com/lovell/sharp/pull/402
+(['fs', 'zip'] as const).forEach(container => {
+  sharp().tile({ container });
+});
+
+// From https://github.com/lovell/sharp/issues/2238
+sharp('input.png').tile({
+  basename: 'output.dz.tiles',
+});

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "module": "commonjs",
+  "strict": true
+}


### PR DESCRIPTION
Treat this as a work-in-progress that we can use to base our discussions from.
Addresses #3369

In essence, this lifts the types from the `@types/sharp` module into the official package, along with the tests that were in that package as well.

Because the types reference node.js types such as `Buffer`, we also need to add a new dependency: `@types/node`. The DefinitelyTyped modules uses the wildcard version range (`*`) in order to prevent multiple copies of the package in the module tree, which often leads to hard to diagnose problems. An alternative would be for us to use `>=14.0.0` or similar. Open to suggestions.

As @lovell pointed out in #3369, this should be considered a minor breaking change, so should likely be released as 0.32.0. When that happens, we can also deprecate `@types/sharp` using the [official process](https://github.com/DefinitelyTyped/DefinitelyTyped#removing-a-package).

Some thoughts:
- While I don't _know_ of any errors in the typings, there is always a chance that there are. I wouldn't be surprised to see a few more PRs popping up to address issues.
- There is starting to be a bit of duplication in documenting things - there is a chance that the jsdoc and the tsdoc is slightly out of sync. Ideally we'd find a better process here, or even consider doing "typescript first" and compiling to js (this is probably controversial - just thinking aloud).
- The "type tests" are somewhat spotty in coverage, and very unstructured. Unless there are plans to migrate to TypeScript fully, I would probably want to restructure these tests a bit over time - splitting them into logical, "sorted" sections of some kind. I'm not sure if it's worth waiting for this work to be completed before a release however - open to suggestions.
