### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci-darwin-arm64v8.yml
+++ b/.github/workflows/ci-darwin-arm64v8.yml
@@ -2,10 +2,11 @@ name: CI (MacStadium)
 on:
   - push
   - pull_request
-permissions:
-  contents: write # for npx prebuild to make release
+permissions: {}
 jobs:
   CI:
+    permissions:
+      contents: write # for npx prebuild to make release
     runs-on: macos-m1
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-darwin-arm64v8.yml
+++ b/.github/workflows/ci-darwin-arm64v8.yml
@@ -2,6 +2,8 @@ name: CI (MacStadium)
 on:
   - push
   - pull_request
+permissions:
+  contents: read # to fetch code (actions/checkout)
 jobs:
   CI:
     runs-on: macos-m1

--- a/.github/workflows/ci-darwin-arm64v8.yml
+++ b/.github/workflows/ci-darwin-arm64v8.yml
@@ -3,7 +3,7 @@ on:
   - push
   - pull_request
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  contents: write # for npx prebuild to make release
 jobs:
   CI:
     runs-on: macos-m1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,15 @@ name: CI (GitHub)
 on:
   - push
   - pull_request
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   CI:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      checks: write # to create new checks (coverallsapp/github-action)
+
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,11 @@ name: CI (GitHub)
 on:
   - push
   - pull_request
-permissions:
-  contents: read # to fetch code (actions/checkout)
-
+permissions: {}
 jobs:
   CI:
     permissions:
-      contents: read # to fetch code (actions/checkout)
+      contents: write # for npx prebuild to make release
       checks: write # to create new checks (coverallsapp/github-action)
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.