### PR TITLE
Update word format in resize docs

### DIFF
--- a/docs/api-resize.md
+++ b/docs/api-resize.md
@@ -14,7 +14,7 @@ When both a `width` and `height` are provided, the possible methods by which the
 
 Some of these values are based on the [object-fit][1] CSS property.
 
-When using a `fit` of `cover` or `contain`, the default **position** is `centre`. Other options are:
+When using a **fit** of `cover` or `contain`, the default **position** is `centre`. Other options are:
 
 *   `sharp.position`: `top`, `right top`, `right`, `right bottom`, `bottom`, `left bottom`, `left`, `left top`.
 *   `sharp.gravity`: `north`, `northeast`, `east`, `southeast`, `south`, `southwest`, `west`, `northwest`, `center` or `centre`.

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -111,7 +111,7 @@ function isResizeExpected (options) {
  *
  * Some of these values are based on the [object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) CSS property.
  *
- * When using a `fit` of `cover` or `contain`, the default **position** is `centre`. Other options are:
+ * When using a **fit** of `cover` or `contain`, the default **position** is `centre`. Other options are:
  * - `sharp.position`: `top`, `right top`, `right`, `right bottom`, `bottom`, `left bottom`, `left`, `left top`.
  * - `sharp.gravity`: `north`, `northeast`, `east`, `southeast`, `south`, `southwest`, `west`, `northwest`, `center` or `centre`.
  * - `sharp.strategy`: `cover` only, dynamically crop using either the `entropy` or `attention` strategy.


### PR DESCRIPTION
Just a little update to avoid confusing fit as a valid keyword for the transformation request