### PR TITLE
chore(docs): Clarify `failOn` setting

### DIFF
--- a/docs/api-constructor.md
+++ b/docs/api-constructor.md
@@ -20,7 +20,7 @@ Implements the [stream.Duplex][1] class.
     JPEG, PNG, WebP, AVIF, GIF, SVG, TIFF or raw pixel image data can be streamed into the object when not present.
 *   `options` **[Object][13]?** if present, is an Object with optional attributes.
 
-    *   `options.failOn` **[string][12]** level of sensitivity to invalid images, one of (in order of sensitivity): 'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels. (optional, default `'warning'`)
+    *   `options.failOn` **[string][12]** Level of sensitivity to invalid images in terms of pixel values. Invalid image headers/metadata will always fail regardless of this setting. One of (in order of sensitivity): 'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels. (optional, default `'warning'`)
     *   `options.limitInputPixels` **([number][14] | [boolean][15])** Do not process input images where the number of pixels
         (width x height) exceeds this limit. Assumes image dimensions contained in the input metadata can be trusted.
         An integral Number of pixels, zero or false to remove limit, true to use default limit of 268402689 (0x3FFF x 0x3FFF). (optional, default `268402689`)

--- a/docs/api-constructor.md
+++ b/docs/api-constructor.md
@@ -20,7 +20,7 @@ Implements the [stream.Duplex][1] class.
     JPEG, PNG, WebP, AVIF, GIF, SVG, TIFF or raw pixel image data can be streamed into the object when not present.
 *   `options` **[Object][13]?** if present, is an Object with optional attributes.
 
-    *   `options.failOn` **[string][12]** level of sensitivity to invalid images, one of (in order of sensitivity): 'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels. (optional, default `'warning'`)
+    *   `options.failOn` **[string][12]** when to abort processing of invalid pixel data, one of (in order of sensitivity): 'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels, invalid metadata will always abort. (optional, default `'warning'`)
     *   `options.limitInputPixels` **([number][14] | [boolean][15])** Do not process input images where the number of pixels
         (width x height) exceeds this limit. Assumes image dimensions contained in the input metadata can be trusted.
         An integral Number of pixels, zero or false to remove limit, true to use default limit of 268402689 (0x3FFF x 0x3FFF). (optional, default `268402689`)

--- a/docs/api-constructor.md
+++ b/docs/api-constructor.md
@@ -20,7 +20,7 @@ Implements the [stream.Duplex][1] class.
     JPEG, PNG, WebP, AVIF, GIF, SVG, TIFF or raw pixel image data can be streamed into the object when not present.
 *   `options` **[Object][13]?** if present, is an Object with optional attributes.
 
-    *   `options.failOn` **[string][12]** Level of sensitivity to invalid images in terms of pixel values. Invalid image headers/metadata will always fail regardless of this setting. One of (in order of sensitivity): 'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels. (optional, default `'warning'`)
+    *   `options.failOn` **[string][12]** level of sensitivity to invalid images, one of (in order of sensitivity): 'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels. (optional, default `'warning'`)
     *   `options.limitInputPixels` **([number][14] | [boolean][15])** Do not process input images where the number of pixels
         (width x height) exceeds this limit. Assumes image dimensions contained in the input metadata can be trusted.
         An integral Number of pixels, zero or false to remove limit, true to use default limit of 268402689 (0x3FFF x 0x3FFF). (optional, default `268402689`)

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -119,7 +119,7 @@ const debuglog = util.debuglog('sharp');
  *  a String containing the filesystem path to an JPEG, PNG, WebP, AVIF, GIF, SVG or TIFF image file.
  *  JPEG, PNG, WebP, AVIF, GIF, SVG, TIFF or raw pixel image data can be streamed into the object when not present.
  * @param {Object} [options] - if present, is an Object with optional attributes.
- * @param {string} [options.failOn='warning'] - level of sensitivity to invalid images, one of (in order of sensitivity): 'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels.
+ * @param {string} [options.failOn='warning'] - when to abort processing of invalid pixel data, one of (in order of sensitivity): 'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels, invalid metadata will always abort.
  * @param {number|boolean} [options.limitInputPixels=268402689] - Do not process input images where the number of pixels
  *  (width x height) exceeds this limit. Assumes image dimensions contained in the input metadata can be trusted.
  *  An integral Number of pixels, zero or false to remove limit, true to use default limit of 268402689 (0x3FFF x 0x3FFF).


### PR DESCRIPTION
## Description

Clarification to the `failOn` setting coming from the discussion in https://github.com/lovell/sharp/issues/3480. Goal of this PR is to set correct expectations of when `failOn` is actually applied internally and which images are always expected to fail regardless of the setting of this

## Related Issues

Fixes https://github.com/lovell/sharp/issues/3480