### PR TITLE
Get real architecture of M1 Mac regardless of Rosetta

### DIFF
--- a/lib/libvips.js
+++ b/lib/libvips.js
@@ -56,9 +56,17 @@ const log = function (item) {
 
 const isRosetta = function () {
   /* istanbul ignore next */
+  log(`Installation info: arch is ${process.arch} & cputype is ${spawnSync('sysctl hw.cputype', spawnSyncOptions).stdout}`);
   if (process.platform === 'darwin' && process.arch === 'x64') {
     const translated = spawnSync('sysctl sysctl.proc_translated', spawnSyncOptions).stdout;
-    return (translated || '').trim() === 'sysctl.proc_translated: 1';
+    // here should return true if the machine is Apple M1 chip while node version is darwin x64
+    let result = (translated || '').trim() === 'sysctl.proc_translated: 1';
+    if (result) {
+      // Determine if it is M1 chip even the node is x64
+      // see: https://stackoverflow.com/questions/65346260/get-real-architecture-of-m1-mac-regardless-of-rosetta
+      const cputype = spawnSync('sysctl hw.cputype', spawnSyncOptions).stdout
+      return (cputype || '').trim() !== 'hw.cputype: 16777228';
+    }
   }
   return false;
 };

--- a/lib/libvips.js
+++ b/lib/libvips.js
@@ -59,7 +59,7 @@ const isRosetta = function () {
   log(`Installation info: arch is ${process.arch} & cputype is ${spawnSync('sysctl hw.cputype', spawnSyncOptions).stdout}`);
   if (process.platform === 'darwin' && process.arch === 'x64') {
     const translated = spawnSync('sysctl sysctl.proc_translated', spawnSyncOptions).stdout;
-    // here should return true if the machine is Apple M1 chip while node version is darwin x64
+    // here should return false if the machine is Apple M1 chip while node version is darwin x64
     let result = (translated || '').trim() === 'sysctl.proc_translated: 1';
     if (result) {
       // Determine if it is M1 chip even the node is x64


### PR DESCRIPTION
Get real architecture of M1 Mac regardless of Rosetta or node version, see #3239 