### PR TITLE
feat: add min and max luminence to stats

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1012,6 +1012,10 @@ declare namespace sharp {
         sharpness: number;
         /** Object containing most dominant sRGB colour based on a 4096-bin 3D histogram (experimental) */
         dominant: { r: number; g: number; b: number };
+        /** Maximum luminence after conversion to CIELAB color space */
+        maxLuminance: number
+        /** Minimum luminence after conversion to CIELAB color space */
+        minLuminance: number
     }
 
     interface ChannelStats {

--- a/src/stats.cc
+++ b/src/stats.cc
@@ -145,11 +145,13 @@ class StatsWorker : public Napi::AsyncWorker {
       info.Set("sharpness", baton->sharpness);
       info.Set("maxLuminance", baton -> maxLuminance);
       info.Set("minLuminance", baton -> minLuminance);
+
       Napi::Object dominant = Napi::Object::New(env);
       dominant.Set("r", baton->dominantRed);
       dominant.Set("g", baton->dominantGreen);
       dominant.Set("b", baton->dominantBlue);
       info.Set("dominant", dominant);
+
       Callback().MakeCallback(Receiver().Value(), { env.Null(), info });
     } else {
       Callback().MakeCallback(Receiver().Value(), { Napi::Error::New(env, baton->err).Value() });

--- a/src/stats.h
+++ b/src/stats.h
@@ -40,6 +40,8 @@ struct StatsBaton {
   int dominantRed;
   int dominantGreen;
   int dominantBlue;
+  int minLuminance;
+  int maxLuminance;
 
   std::string err;
 
@@ -50,7 +52,9 @@ struct StatsBaton {
     sharpness(0.0),
     dominantRed(0),
     dominantGreen(0),
-    dominantBlue(0)
+    dominantBlue(0),
+    minLuminance(0),
+    maxLuminance(0)
     {}
 };
 


### PR DESCRIPTION
Return the min and maximum luminance levels based on the `lch` colourspace