### PR TITLE
Fix notation of proxy URL in logs

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -30,7 +30,7 @@ module.exports = function (log) {
     const proxyAuth = proxy.username && proxy.password
       ? `${decodeURIComponent(proxy.username)}:${decodeURIComponent(proxy.password)}`
       : null;
-    log(`Via proxy ${proxy.protocol}://${proxy.hostname}:${proxy.port} ${proxyAuth ? 'with' : 'no'} credentials`);
+    log(`Via proxy ${proxy.protocol}//${proxy.hostname}:${proxy.port} ${proxyAuth ? 'with' : 'no'} credentials`);
     return tunnel({
       proxy: {
         port: Number(proxy.port),

--- a/test/unit/agent.js
+++ b/test/unit/agent.js
@@ -21,7 +21,7 @@ describe('HTTP agent', function () {
     assert.strictEqual(123, proxy.options.proxy.port);
     assert.strictEqual('user:pass', proxy.options.proxy.proxyAuth);
     assert.strictEqual(443, proxy.defaultPort);
-    assert.strictEqual(logMsg, 'Via proxy https:://secure:123 with credentials');
+    assert.strictEqual(logMsg, 'Via proxy https://secure:123 with credentials');
   });
 
   it('HTTPS proxy with auth from HTTPS_PROXY using credentials containing special characters', function () {
@@ -34,7 +34,7 @@ describe('HTTP agent', function () {
     assert.strictEqual(789, proxy.options.proxy.port);
     assert.strictEqual('user,:pass=', proxy.options.proxy.proxyAuth);
     assert.strictEqual(443, proxy.defaultPort);
-    assert.strictEqual(logMsg, 'Via proxy https:://secure:789 with credentials');
+    assert.strictEqual(logMsg, 'Via proxy https://secure:789 with credentials');
   });
 
   it('HTTP proxy without auth from npm_config_proxy', function () {
@@ -47,6 +47,6 @@ describe('HTTP agent', function () {
     assert.strictEqual(456, proxy.options.proxy.port);
     assert.strictEqual(null, proxy.options.proxy.proxyAuth);
     assert.strictEqual(443, proxy.defaultPort);
-    assert.strictEqual(logMsg, 'Via proxy http:://plaintext:456 no credentials');
+    assert.strictEqual(logMsg, 'Via proxy http://plaintext:456 no credentials');
   });
 });


### PR DESCRIPTION
While debugging an unrelated proxy error, I stumbled upon an incorrect display of the proxy URL. Instead of displaying `http://example.com:1234`, `http:://example.com:1234` is being displayed. This may case some serious confusion.

As far as my understanding goes, this only impacts the actual display within the logs. But I must say that I'm not completely sure of that.

This PR corrects this log line and relevant tests.