### PR TITLE
fixed method toFile(), param "fileOut" jpeg2000 file extension check

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -75,7 +75,7 @@ function toFile (fileOut, callback) {
     err = new Error('Missing output file path');
   } else if (is.string(this.options.input.file) && path.resolve(this.options.input.file) === path.resolve(fileOut)) {
     err = new Error('Cannot use same file for input and output');
-  } else if (jp2Regex.test(fileOut) && !this.constructor.format.jp2k.output.file) {
+  } else if (jp2Regex.test(path.extname(fileOut)) && !this.constructor.format.jp2k.output.file) {
     err = errJp2Save();
   }
   if (err) {


### PR DESCRIPTION
fixed method toFile(), param "fileOut" jpeg2000 file extension check
------------------------------------
The RE matches the file extension directly rather than the entire path，
The result will be much closer to correct.