### PR TITLE
Tests: ensure Jimp uses bicubic as the resizing kernel

### DIFF
--- a/test/bench/perf.js
+++ b/test/bench/perf.js
@@ -652,7 +652,7 @@ async.series({
             throw err;
           } else {
             image
-              .resize(width, heightPng)
+              .resize(width, heightPng, jimp.RESIZE_BICUBIC)
               .deflateLevel(6)
               .filterType(0)
               .getBuffer(jimp.MIME_PNG, function (err) {
@@ -673,7 +673,7 @@ async.series({
             throw err;
           } else {
             image
-              .resize(width, heightPng)
+              .resize(width, heightPng, jimp.RESIZE_BICUBIC)
               .deflateLevel(6)
               .filterType(0)
               .write(outputPng, function (err) {


### PR DESCRIPTION
Otherwise it'll default to bilinear (`jimp.RESIZE_BILINEAR`), which is faster than bicubic but less accurate.

This corresponds to what is done in the JPEG benchmark suite:
https://github.com/lovell/sharp/blob/0bc79cdb953c9c0f1cf9015be65fb231fd5ec520/test/bench/perf.js#L59
https://github.com/lovell/sharp/blob/0bc79cdb953c9c0f1cf9015be65fb231fd5ec520/test/bench/perf.js#L79