### PR TITLE
Added webp preset types and test for same. Issue 3747

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -146,6 +146,7 @@ declare namespace sharp {
     const kernel: KernelEnum;
     const fit: FitEnum;
     const bool: BoolEnum;
+    const preset: PresetEnum
 
     interface Sharp extends Duplex {
         //#region Channel functions
@@ -1127,6 +1128,8 @@ declare namespace sharp {
         minSize?: number;
         /** Allow mixture of lossy and lossless animation frames (slow) (optional, default false) */
         mixed?: boolean;
+        /** Preset options: one of default, photo, picture, drawing, icon, text (optional, default 'default') */
+        preset?: keyof PresetEnum | undefined;
     }
 
     interface AvifOptions extends OutputOptions {
@@ -1474,6 +1477,15 @@ declare namespace sharp {
         mitchell: 'mitchell';
         lanczos2: 'lanczos2';
         lanczos3: 'lanczos3';
+    }
+
+    interface PresetEnum {
+        default: 'default';
+        picture: 'picture';
+        photo: 'photo';
+        drawing: 'drawing';
+        icon: 'icon';
+        text: 'text';
     }
 
     interface BoolEnum {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -146,7 +146,6 @@ declare namespace sharp {
     const kernel: KernelEnum;
     const fit: FitEnum;
     const bool: BoolEnum;
-    const preset: WebpPresetEnum
 
     interface Sharp extends Duplex {
         //#region Channel functions
@@ -1129,7 +1128,7 @@ declare namespace sharp {
         /** Allow mixture of lossy and lossless animation frames (slow) (optional, default false) */
         mixed?: boolean;
         /** Preset options: one of default, photo, picture, drawing, icon, text (optional, default 'default') */
-        preset?: keyof WebpPresetEnum | undefined;
+        preset?: keyof PresetEnum | undefined;
     }
 
     interface AvifOptions extends OutputOptions {
@@ -1479,7 +1478,7 @@ declare namespace sharp {
         lanczos3: 'lanczos3';
     }
 
-    interface WebpPresetEnum {
+    interface PresetEnum {
         default: 'default';
         picture: 'picture';
         photo: 'photo';

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -146,7 +146,7 @@ declare namespace sharp {
     const kernel: KernelEnum;
     const fit: FitEnum;
     const bool: BoolEnum;
-    const preset: PresetEnum
+    const preset: WebpPresetEnum
 
     interface Sharp extends Duplex {
         //#region Channel functions
@@ -1129,7 +1129,7 @@ declare namespace sharp {
         /** Allow mixture of lossy and lossless animation frames (slow) (optional, default false) */
         mixed?: boolean;
         /** Preset options: one of default, photo, picture, drawing, icon, text (optional, default 'default') */
-        preset?: keyof PresetEnum | undefined;
+        preset?: keyof WebpPresetEnum | undefined;
     }
 
     interface AvifOptions extends OutputOptions {
@@ -1479,7 +1479,7 @@ declare namespace sharp {
         lanczos3: 'lanczos3';
     }
 
-    interface PresetEnum {
+    interface WebpPresetEnum {
         default: 'default';
         picture: 'picture';
         photo: 'photo';

--- a/test/types/sharp.test-d.ts
+++ b/test/types/sharp.test-d.ts
@@ -660,5 +660,4 @@ sharp('input.tiff').webp({ preset: 'icon' }).toFile('out.webp');
 sharp('input.tiff').webp({ preset: 'drawing' }).toFile('out.webp');
 sharp('input.tiff').webp({ preset: 'text' }).toFile('out.webp');
 sharp('input.tiff').webp({ preset: 'default' }).toFile('out.webp');
-sharp('input.tiff').webp({ preset: sharp.preset.photo }).toFile('out.webp');
 

--- a/test/types/sharp.test-d.ts
+++ b/test/types/sharp.test-d.ts
@@ -651,3 +651,14 @@ sharp(input).composite([
     unlimited: true,
   }
 ]);
+
+// Support for webp preset in types
+// https://github.com/lovell/sharp/issues/3747
+sharp('input.tiff').webp({ preset: 'photo' }).toFile('out.webp');
+sharp('input.tiff').webp({ preset: 'picture' }).toFile('out.webp');
+sharp('input.tiff').webp({ preset: 'icon' }).toFile('out.webp');
+sharp('input.tiff').webp({ preset: 'drawing' }).toFile('out.webp');
+sharp('input.tiff').webp({ preset: 'text' }).toFile('out.webp');
+sharp('input.tiff').webp({ preset: 'default' }).toFile('out.webp');
+sharp('input.tiff').webp({ preset: sharp.preset.photo }).toFile('out.webp');
+


### PR DESCRIPTION
For issue https://github.com/lovell/sharp/issues/3747.

The webp output options type is missing the preset values in the types.  They are present in the js library.
This PR adds:
* A new enum  (`PresetEnum`)
* The preset on `WebpOptions`
* The enum as `sharp.preset` on `sharp`.
* Tests for both string and enum based use of `webp({preset: ...})`

This follows the same implementation as other options, such as resize.fit.

npm test-types and npm test-lint both run cleanly.
