### PR TITLE
Fix build with musl 1.2.4

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -20,18 +20,15 @@
 #include "operations.h"
 #include "pipeline.h"
 
-#if defined(WIN32)
+#ifdef _WIN32
 #define STAT64_STRUCT __stat64
 #define STAT64_FUNCTION _stat64
-#elif defined(__APPLE__)
-#define STAT64_STRUCT stat
-#define STAT64_FUNCTION stat
-#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
-#define STAT64_STRUCT stat
-#define STAT64_FUNCTION stat
-#else
+#elif defined(_LARGEFILE64_SOURCE)
 #define STAT64_STRUCT stat64
 #define STAT64_FUNCTION stat64
+#else
+#define STAT64_STRUCT stat
+#define STAT64_FUNCTION stat
 #endif
 
 class PipelineWorker : public Napi::AsyncWorker {


### PR DESCRIPTION
musl 1.2.4 has removed the legacy LFS64 glibc-ABI-compat symbols, which would cause an error during `npm install sharp` when compiled from source (either with the `--build-from-source` flag or when a globally installed libvips is detected).

> On the API level, the legacy "LFS64" ("large file support") interfaces, which were provided by macros remapping them to their standard names (`#define stat64 stat` and similar) have been deprecated and are no longer provided under the `_GNU_SOURCE` feature profile, only under explicit `_LARGEFILE64_SOURCE`. The latter will also be removed in a future version. Builds broken by this change can be fixed short-term by adding `-D_LARGEFILE64_SOURCE` to `CFLAGS`, but should be fixed to use the standard interfaces.
> https://musl.libc.org/releases.html

The fix is to replace the OS-specific `#ifdef`'s with a single one that checks whether [`_LARGEFILE64_SOURCE`](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html#index-_005fLARGEFILE64_005fSOURCE:~:text=The%20new%20functionality%20is%20made%20available%20by%20a%20new%20set%20of%20types%20and%20functions%20which%20replace%20the%20existing%20ones.%20The%20names%20of%20these%20new%20objects%20contain%2064%20to%20indicate%20the%20intention%2C%20e.g.%2C%20off_t%20vs.%20off64_t%20and%20fseeko%20vs.%20fseeko64.) is defined. Other libc implementations that provide nondegenerate LFS64 interfaces are expected to define this macro as well.

<details>
  <summary>Reproducer</summary>

```bash
$ mkdir sharp-musl && cd sharp-musl
$ docker run -v $(pwd):/app -w /app -it alpine:edge sh -c "\
    apk add build-base git npm python3 vips-cpp vips-dev && \
    npm install --build-from-source sharp"
```
```console
...
npm ERR! ../src/pipeline.cc: In member function 'virtual void PipelineWorker::OnOK()':
npm ERR! ../src/pipeline.cc:1267:30: error: aggregate 'PipelineWorker::OnOK()::stat64 st' has incomplete type and cannot be defined
npm ERR!  1267 |         struct STAT64_STRUCT st;
npm ERR!       |                              ^~
npm ERR! ../src/pipeline.cc:1268:55: error: invalid use of incomplete type 'struct PipelineWorker::OnOK()::stat64'
npm ERR!  1268 |         if (STAT64_FUNCTION(baton->fileOut.data(), &st) == 0) {
npm ERR!       |                                                       ^
npm ERR! ../src/pipeline.cc:33:23: note: forward declaration of 'struct PipelineWorker::OnOK()::stat64'
npm ERR!    33 | #define STAT64_STRUCT stat64
npm ERR!       |                       ^~~~~~
npm ERR! ../src/pipeline.cc:1267:16: note: in expansion of macro 'STAT64_STRUCT'
npm ERR!  1267 |         struct STAT64_STRUCT st;
npm ERR!       |                ^~~~~~~~~~~~~
npm ERR! make: *** [sharp-linuxmusl-x64.target.mk:169: Release/obj.target/sharp-linuxmusl-x64/src/pipeline.o] Error 1
...
```
</details>
