### PR TITLE
fix Type bug in WebpOptions.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1124,7 +1124,7 @@ declare namespace sharp {
         /** Level of CPU effort to reduce file size, integer 0-6 (optional, default 4) */
         effort?: number | undefined;
         /** Prevent use of animation key frames to minimise file size (slow) (optional, default false) */
-        minSize?: number;
+        minSize?: boolean;
         /** Allow mixture of lossy and lossless animation frames (slow) (optional, default false) */
         mixed?: boolean;
         /** Preset options: one of default, photo, picture, drawing, icon, text (optional, default 'default') */

--- a/test/types/sharp.test-d.ts
+++ b/test/types/sharp.test-d.ts
@@ -524,7 +524,7 @@ sharp('input.tiff').jxl({ lossless: true }).toFile('out.jxl');
 sharp('input.tiff').jxl({ effort: 7 }).toFile('out.jxl');
 
 // Support `minSize` and `mixed` webp options
-sharp('input.tiff').webp({ minSize: 1000, mixed: true }).toFile('out.gif');
+sharp('input.tiff').webp({ minSize: true, mixed: true }).toFile('out.gif');
 
 // 'failOn' input param
 sharp('input.tiff', { failOn: 'none' });


### PR DESCRIPTION
While use sharp to convert to WebP with TypeScript, I found the Type Error of `WebpOptions.minSize`.
it param is boolean, but Type specify as number.
So we had going to use `@ts-tsgnore`  when use this option.

This PR corrects this bug.