### PR TITLE
support miniswhite for tiff output

### DIFF
--- a/docs/api-output.md
+++ b/docs/api-output.md
@@ -458,6 +458,7 @@ instead of providing `xres` and `yres` in pixels/mm.
 | [options.force] | <code>boolean</code> | <code>true</code> | force TIFF output, otherwise attempt to use input format |
 | [options.compression] | <code>string</code> | <code>&quot;&#x27;jpeg&#x27;&quot;</code> | compression options: none, jpeg, deflate, packbits, ccittfax4, lzw, webp, zstd, jp2k |
 | [options.predictor] | <code>string</code> | <code>&quot;&#x27;horizontal&#x27;&quot;</code> | compression predictor options: none, horizontal, float |
+| [options.miniswhite] | <code>boolean</code> | <code>false</code> | write 1-bit images as miniswhite |
 | [options.pyramid] | <code>boolean</code> | <code>false</code> | write an image pyramid |
 | [options.tile] | <code>boolean</code> | <code>false</code> | write a tiled tiff |
 | [options.tileWidth] | <code>number</code> | <code>256</code> | horizontal tile size |

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -306,6 +306,7 @@ const Sharp = function (input, options) {
     tiffCompression: 'jpeg',
     tiffPredictor: 'horizontal',
     tiffPyramid: false,
+    tiffMiniswhite: false,
     tiffBitdepth: 8,
     tiffTile: false,
     tiffTileHeight: 256,

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1227,6 +1227,8 @@ declare namespace sharp {
         compression?: string | undefined;
         /** Compression predictor options: none, horizontal, float (optional, default 'horizontal') */
         predictor?: string | undefined;
+        /** Write 1-bit images as miniswhite (optional, default false) */
+        miniswhite?: boolean | undefined;
         /** Write an image pyramid (optional, default false) */
         pyramid?: boolean | undefined;
         /** Write a tiled tiff (optional, default false) */

--- a/lib/output.js
+++ b/lib/output.js
@@ -771,6 +771,7 @@ function trySetAnimationOptions (source, target) {
  * @param {number} [options.quality=80] - quality, integer 1-100
  * @param {boolean} [options.force=true] - force TIFF output, otherwise attempt to use input format
  * @param {string} [options.compression='jpeg'] - compression options: none, jpeg, deflate, packbits, ccittfax4, lzw, webp, zstd, jp2k
+ * @param {boolean} [options.miniswhite=false] - write 1-bit images as miniswhite
  * @param {string} [options.predictor='horizontal'] - compression predictor options: none, horizontal, float
  * @param {boolean} [options.pyramid=false] - write an image pyramid
  * @param {boolean} [options.tile=false] - write a tiled tiff
@@ -816,6 +817,10 @@ function tiff (options) {
       } else {
         throw is.invalidParameterError('tileHeight', 'integer greater than zero', options.tileHeight);
       }
+    }
+    // miniswhite
+    if (is.defined(options.miniswhite)) {
+      this._setBooleanOption('tiffMiniswhite', options.miniswhite);
     }
     // pyramid
     if (is.defined(options.pyramid)) {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "Ankur Parihar <ankur.github@gmail.com>",
     "Brahim Ait elhaj <brahima@gmail.com>",
     "Mart Jansink <m.jansink@gmail.com>",
-    "Lachlan Newman <lachnewman007@gmail.com>"
+    "Lachlan Newman <lachnewman007@gmail.com>",
+    "Dennis Beatty <dennis@dcbeatty.com>"
   ],
   "scripts": {
     "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node install/can-compile && node-gyp rebuild && node install/dll-copy)",

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -940,6 +940,7 @@ class PipelineWorker : public Napi::AsyncWorker {
             ->set("Q", baton->tiffQuality)
             ->set("bitdepth", baton->tiffBitdepth)
             ->set("compression", baton->tiffCompression)
+            ->set("miniswhite", baton->tiffMiniswhite)
             ->set("predictor", baton->tiffPredictor)
             ->set("pyramid", baton->tiffPyramid)
             ->set("tile", baton->tiffTile)
@@ -1136,6 +1137,7 @@ class PipelineWorker : public Napi::AsyncWorker {
             ->set("Q", baton->tiffQuality)
             ->set("bitdepth", baton->tiffBitdepth)
             ->set("compression", baton->tiffCompression)
+            ->set("miniswhite", baton->tiffMiniswhite)
             ->set("predictor", baton->tiffPredictor)
             ->set("pyramid", baton->tiffPyramid)
             ->set("tile", baton->tiffTile)
@@ -1647,6 +1649,7 @@ Napi::Value pipeline(const Napi::CallbackInfo& info) {
   baton->gifProgressive = sharp::AttrAsBool(options, "gifProgressive");
   baton->tiffQuality = sharp::AttrAsUint32(options, "tiffQuality");
   baton->tiffPyramid = sharp::AttrAsBool(options, "tiffPyramid");
+  baton->tiffMiniswhite = sharp::AttrAsBool(options, "tiffMiniswhite");
   baton->tiffBitdepth = sharp::AttrAsUint32(options, "tiffBitdepth");
   baton->tiffTile = sharp::AttrAsBool(options, "tiffTile");
   baton->tiffTileWidth = sharp::AttrAsUint32(options, "tiffTileWidth");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -169,6 +169,7 @@ struct PipelineBaton {
   VipsForeignTiffPredictor tiffPredictor;
   bool tiffPyramid;
   int tiffBitdepth;
+  bool tiffMiniswhite;
   bool tiffTile;
   int tiffTileHeight;
   int tiffTileWidth;
@@ -333,6 +334,7 @@ struct PipelineBaton {
     tiffQuality(80),
     tiffCompression(VIPS_FOREIGN_TIFF_COMPRESSION_JPEG),
     tiffPredictor(VIPS_FOREIGN_TIFF_PREDICTOR_HORIZONTAL),
+    tiffMiniswhite(false),
     tiffPyramid(false),
     tiffBitdepth(8),
     tiffTile(false),

--- a/test/unit/tiff.js
+++ b/test/unit/tiff.js
@@ -462,6 +462,18 @@ describe('TIFF', function () {
     });
   });
 
+  it('TIFF miniswhite true value does not throw error', function () {
+    assert.doesNotThrow(function () {
+      sharp().tiff({ miniswhite: true });
+    });
+  });
+
+  it('Invalid TIFF miniswhite value throws error', function () {
+    assert.throws(function () {
+      sharp().tiff({ miniswhite: 'true' });
+    });
+  });
+
   it('Invalid TIFF tile value throws error', function () {
     assert.throws(function () {
       sharp().tiff({ tile: 'true' });


### PR DESCRIPTION
This adds support for the `miniswhite` option when outputting to a tiff file, and closes #3186.