### PR TITLE
Correctly check for when sharp is unavailable

### DIFF
--- a/lib/sharp.js
+++ b/lib/sharp.js
@@ -17,10 +17,11 @@ const paths = [
   '@img/sharp-wasm32/sharp.node'
 ];
 
+let sharp;
 const errors = [];
 for (const path of paths) {
   try {
-    module.exports = require(path);
+    sharp = require(path);
     break;
   } catch (err) {
     /* istanbul ignore next */
@@ -29,7 +30,9 @@ for (const path of paths) {
 }
 
 /* istanbul ignore next */
-if (!module.exports) {
+if (sharp) {
+  module.exports = sharp;
+} else {
   const [isLinux, isMacOs, isWindows] = ['linux', 'darwin', 'win32'].map(os => runtimePlatform.startsWith(os));
 
   const help = [`Could not load the "sharp" module using the ${runtimePlatform} runtime`];


### PR DESCRIPTION
Find while investigating issues with https://github.com/nuxt/image/pull/1102

`module.exports` defaults to an empty object `{}`, if no sources are available, we were not detecting it. 

PS: Let me know if you prefer another style for changes.