### PR TITLE
use $NODE rather than node for install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "Lachlan Newman <lachnewman007@gmail.com>"
   ],
   "scripts": {
-    "install": "(node install/libvips && node install/dll-copy && prebuild-install) || (node install/can-compile && node-gyp rebuild && node install/dll-copy)",
+    "install": "(\"$NODE\" install/libvips && \"$NODE\" install/dll-copy && prebuild-install) || (\"$NODE\" install/can-compile && node-gyp rebuild && \"$NODE\" install/dll-copy)",
     "clean": "rm -rf node_modules/ build/ vendor/ .nyc_output/ coverage/ test/fixtures/output.*",
     "test": "npm run test-lint && npm run test-unit && npm run test-licensing && npm run test-types",
     "test-lint": "semistandard && cpplint",


### PR DESCRIPTION
when the runtime used to npm install is not node (ie, electron), the `node` binary will not be in path or available. use the $NODE env instead, as that is provided by npm/node/electron.
