### PR TITLE
Fixed VIPS_NOVECTOR correct work

### DIFF
--- a/lib/utility.js
+++ b/lib/utility.js
@@ -201,7 +201,6 @@ function counters () {
 function simd (simd) {
   return sharp.simd(is.bool(simd) ? simd : null);
 }
-simd([0, "0", "false"].includes(process.env.VIPS_NOVECTOR) ? false : true);
 
 /**
  * Block libvips operations at runtime.

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -201,7 +201,7 @@ function counters () {
 function simd (simd) {
   return sharp.simd(is.bool(simd) ? simd : null);
 }
-simd(true);
+simd([0, "0", "false"].includes(process.env.VIPS_NOVECTOR) ? false : true);
 
 /**
  * Block libvips operations at runtime.


### PR DESCRIPTION
Based on the #3893 issue, there was a setting problem, which is fixed with this modification. If the `process.env.VIPS_NOVECTOR=0`, then simd set `false` in default.