### PR TITLE
CI: Update Emscripten Docker image to 3.1.51

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
       contents: write
     name: wasm32 - prebuild
     runs-on: ubuntu-22.04
-    container: "emscripten/emsdk:3.1.48"
+    container: "emscripten/emsdk:3.1.51"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Emscripten does not guarantee ABI compatibility across its versions, so we need ensure that this version is kept in-sync with the wasm-vips project.
> ```md
> Note that there is *no* ABI compatibility guarantee between versions - the ABI
> may change, so that we can keep improving and optimizing it. The compiler will
> automatically invalidate system caches when the version number updates, so that
> libc etc. are rebuilt for you. You should also rebuild object files and
> libraries in your project when you upgrade emscripten.
> ```
> _From: https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md?plain=1#L7-L11_

Depends on: https://github.com/lovell/sharp-libvips/pull/212.