### PR TITLE
Added typescript prompt for keepmetadata

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -342,6 +342,12 @@ declare namespace sharp {
         metadata(): Promise<Metadata>;
 
         /**
+         * Keep all metadata (EXIF, ICC, XMP, IPTC) from the input image in the output image.
+         * @returns A sharp instance that can be used to chain operations
+         */
+        keepMetadata(): Sharp;
+
+        /**
          * Access to pixel-derived image statistics for every channel in the image.
          * @returns A sharp instance that can be used to chain operations
          */

--- a/test/types/sharp.test-d.ts
+++ b/test/types/sharp.test-d.ts
@@ -44,6 +44,12 @@ sharp('input.png')
     // sharpened, with metadata, 90% quality WebP image data. Phew!
   });
 
+sharp('input.png')
+  .keepMetadata()
+  .toFile('output.png', (err, info) => {
+    // output.png is an image containing input.png along with all metadata(EXIF, ICC, XMP, IPTC) from input.png
+  })
+
 sharp('input.jpg')
   .resize(300, 200)
   .toFile('output.jpg', (err: Error) => {


### PR DESCRIPTION
This PR adds keepMetaData type to Sharp instance.

See #3908 for more context.