### PR TITLE
docs(install): Write full supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ smaller, web-friendly JPEG, PNG, WebP, GIF and AVIF images of varying dimensions
 
 It can be used with all JavaScript runtimes
 that provide support for Node-API v9, including
-Node.js >= 18.17.0, Deno and Bun.
+Node.js (^18.17.0 or >= 20.3.0), Deno and Bun.
 
 Resizing an image is typically 4x-5x faster than using the
 quickest ImageMagick and GraphicsMagick settings

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,7 +27,7 @@ Requires libvips v8.15.0
 
 ### v0.33.0 - 29th November 2023
 
-* Drop support for Node.js 14 and 16, now requires Node.js >= 18.17.0
+* Drop support for Node.js 14 and 16, now requires Node.js ^18.17.0 or >= 20.3.0
 
 * Prebuilt binaries distributed via npm registry and installed via package manager.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,7 @@ deno run --allow-ffi ...
 
 ## Prerequisites
 
-- Node-API v9 compatible runtime e.g. Node.js ^18.17.0 or >=20.3.0.
+* Node-API v9 compatible runtime e.g. Node.js ^18.17.0 or >=20.3.0.
 
 ## Prebuilt binaries
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,7 @@ deno run --allow-ffi ...
 
 ## Prerequisites
 
-* Node-API v9 compatible runtime e.g. Node.js >= 18.17.0
+- Node-API v9 compatible runtime e.g. Node.js ^18.17.0 or >=20.3.0.
 
 ## Prebuilt binaries
 


### PR DESCRIPTION
Hello!

I'm not too picky on the exact format, so feel free to reformat in a way you prefer, but I found it confusing how the "semver" version mention in the docs wasn't accurate, `>= 18.17.0` implies that any versions after `18.17.0` works, but that is not the case. For instance, someone on `20.2.x` will fail to install Sharp, as will someone on `19.x.x`. 

This caused a few downstream issues in repos I maintain that have Sharp as an `optionalDependencies` because users didn't get an error on install (since it's an optionalDep), but as far as they could tell from the Sharp docs, they had a supported version of Node.