### PR TITLE
fix: typo error text.wrap

### DIFF
--- a/docs/api-constructor.md
+++ b/docs/api-constructor.md
@@ -66,7 +66,7 @@ where the overall height is the `pageHeight` multiplied by the number of `pages`
 | [options.text.dpi] | <code>number</code> | <code>72</code> | the resolution (size) at which to render the text. Does not take effect if `height` is specified. |
 | [options.text.rgba] | <code>boolean</code> | <code>false</code> | set this to true to enable RGBA output. This is useful for colour emoji rendering, or support for pango markup features like `<span foreground="red">Red!</span>`. |
 | [options.text.spacing] | <code>number</code> | <code>0</code> | text line height in points. Will use the font line height if none is specified. |
-| [options.text.wrap] | <code>string</code> | <code>&quot;&#x27;word&#x27;&quot;</code> | word wrapping style when width is provided, one of: 'word', 'char', 'wordChar' (prefer char, fallback to word) or 'none'. |
+| [options.text.wrap] | <code>string</code> | <code>&quot;&#x27;word&#x27;&quot;</code> | word wrapping style when width is provided, one of: 'word', 'char', 'word-char' (prefer word, fallback to char) or 'none'. |
 
 **Example**  
 ```js

--- a/docs/api-constructor.md
+++ b/docs/api-constructor.md
@@ -66,7 +66,7 @@ where the overall height is the `pageHeight` multiplied by the number of `pages`
 | [options.text.dpi] | <code>number</code> | <code>72</code> | the resolution (size) at which to render the text. Does not take effect if `height` is specified. |
 | [options.text.rgba] | <code>boolean</code> | <code>false</code> | set this to true to enable RGBA output. This is useful for colour emoji rendering, or support for pango markup features like `<span foreground="red">Red!</span>`. |
 | [options.text.spacing] | <code>number</code> | <code>0</code> | text line height in points. Will use the font line height if none is specified. |
-| [options.text.wrap] | <code>string</code> | <code>&quot;&#x27;word&#x27;&quot;</code> | word wrapping style when width is provided, one of: 'word', 'char', 'charWord' (prefer char, fallback to word) or 'none'. |
+| [options.text.wrap] | <code>string</code> | <code>&quot;&#x27;word&#x27;&quot;</code> | word wrapping style when width is provided, one of: 'word', 'char', 'wordChar' (prefer char, fallback to word) or 'none'. |
 
 **Example**  
 ```js

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -166,7 +166,7 @@ const debuglog = util.debuglog('sharp');
  * @param {number} [options.text.dpi=72] - the resolution (size) at which to render the text. Does not take effect if `height` is specified.
  * @param {boolean} [options.text.rgba=false] - set this to true to enable RGBA output. This is useful for colour emoji rendering, or support for pango markup features like `<span foreground="red">Red!</span>`.
  * @param {number} [options.text.spacing=0] - text line height in points. Will use the font line height if none is specified.
- * @param {string} [options.text.wrap='word'] - word wrapping style when width is provided, one of: 'word', 'char', 'wordChar' (prefer char, fallback to word) or 'none'.
+ * @param {string} [options.text.wrap='word'] - word wrapping style when width is provided, one of: 'word', 'char', 'word-char' (prefer word, fallback to char) or 'none'.
  * @returns {Sharp}
  * @throws {Error} Invalid parameters
  */

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -166,7 +166,7 @@ const debuglog = util.debuglog('sharp');
  * @param {number} [options.text.dpi=72] - the resolution (size) at which to render the text. Does not take effect if `height` is specified.
  * @param {boolean} [options.text.rgba=false] - set this to true to enable RGBA output. This is useful for colour emoji rendering, or support for pango markup features like `<span foreground="red">Red!</span>`.
  * @param {number} [options.text.spacing=0] - text line height in points. Will use the font line height if none is specified.
- * @param {string} [options.text.wrap='word'] - word wrapping style when width is provided, one of: 'word', 'char', 'charWord' (prefer char, fallback to word) or 'none'.
+ * @param {string} [options.text.wrap='word'] - word wrapping style when width is provided, one of: 'word', 'char', 'wordChar' (prefer char, fallback to word) or 'none'.
  * @returns {Sharp}
  * @throws {Error} Invalid parameters
  */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1017,7 +1017,7 @@ declare namespace sharp {
         rgba?: boolean;
         /** Text line height in points. Will use the font line height if none is specified. (optional, default `0`) */
         spacing?: number;
-        /** Word wrapping style when width is provided, one of: 'word', 'char', 'wordChar' (prefer char, fallback to word) or 'none' */
+        /** Word wrapping style when width is provided, one of: 'word', 'char', 'word-char' (prefer word, fallback to char) or 'none' */
         wrap?: TextWrap;
     }
 
@@ -1613,7 +1613,7 @@ declare namespace sharp {
 
     type TextAlign = 'left' | 'centre' | 'center' | 'right';
 
-    type TextWrap = 'word' | 'char' | 'wordChar' | 'none';
+    type TextWrap = 'word' | 'char' | 'word-char' | 'none';
 
     type TileContainer = 'fs' | 'zip';
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1017,7 +1017,7 @@ declare namespace sharp {
         rgba?: boolean;
         /** Text line height in points. Will use the font line height if none is specified. (optional, default `0`) */
         spacing?: number;
-        /** Word wrapping style when width is provided, one of: 'word', 'char', 'charWord' (prefer char, fallback to word) or 'none' */
+        /** Word wrapping style when width is provided, one of: 'word', 'char', 'wordChar' (prefer char, fallback to word) or 'none' */
         wrap?: TextWrap;
     }
 
@@ -1613,7 +1613,7 @@ declare namespace sharp {
 
     type TextAlign = 'left' | 'centre' | 'center' | 'right';
 
-    type TextWrap = 'word' | 'char' | 'charWord' | 'none';
+    type TextWrap = 'word' | 'char' | 'wordChar' | 'none';
 
     type TileContainer = 'fs' | 'zip';
 

--- a/lib/input.js
+++ b/lib/input.js
@@ -345,10 +345,10 @@ function _createInputDescriptor (input, inputOptions, containerOptions) {
           }
         }
         if (is.defined(inputOptions.text.wrap)) {
-          if (is.string(inputOptions.text.wrap) && is.inArray(inputOptions.text.wrap, ['word', 'char', 'wordChar', 'none'])) {
+          if (is.string(inputOptions.text.wrap) && is.inArray(inputOptions.text.wrap, ['word', 'char', 'word-char', 'none'])) {
             inputDescriptor.textWrap = inputOptions.text.wrap;
           } else {
-            throw is.invalidParameterError('text.wrap', 'one of: word, char, wordChar, none', inputOptions.text.wrap);
+            throw is.invalidParameterError('text.wrap', 'one of: word, char, word-char, none', inputOptions.text.wrap);
           }
         }
         delete inputDescriptor.buffer;

--- a/test/types/sharp.test-d.ts
+++ b/test/types/sharp.test-d.ts
@@ -595,7 +595,7 @@ sharp({
     rgba: true,
     justify: true,
     spacing: 10,
-    wrap: 'wordChar',
+    wrap: 'word-char',
   },
 })
   .png()

--- a/test/types/sharp.test-d.ts
+++ b/test/types/sharp.test-d.ts
@@ -595,7 +595,7 @@ sharp({
     rgba: true,
     justify: true,
     spacing: 10,
-    wrap: 'charWord',
+    wrap: 'wordChar',
   },
 })
   .png()

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -319,21 +319,21 @@ describe('Text to image', function () {
 
   it('valid wrap throws', () => {
     assert.doesNotThrow(() => sharp({ text: { text: 'text', wrap: 'none' } }));
-    assert.doesNotThrow(() => sharp({ text: { text: 'text', wrap: 'wordChar' } }));
+    assert.doesNotThrow(() => sharp({ text: { text: 'text', wrap: 'word-char' } }));
   });
 
   it('invalid wrap throws', () => {
     assert.throws(
       () => sharp({ text: { text: 'text', wrap: 1 } }),
-      /Expected one of: word, char, wordChar, none for text\.wrap but received 1 of type number/
+      /Expected one of: word, char, word-char, none for text\.wrap but received 1 of type number/
     );
     assert.throws(
       () => sharp({ text: { text: 'text', wrap: false } }),
-      /Expected one of: word, char, wordChar, none for text\.wrap but received false of type boolean/
+      /Expected one of: word, char, word-char, none for text\.wrap but received false of type boolean/
     );
     assert.throws(
       () => sharp({ text: { text: 'text', wrap: 'invalid' } }),
-      /Expected one of: word, char, wordChar, none for text\.wrap but received invalid of type string/
+      /Expected one of: word, char, word-char, none for text\.wrap but received invalid of type string/
     );
   });
 });


### PR DESCRIPTION
fix text.wrap typo error  and TypeScript type defined error
![Screen Shot 2024-03-14 at 22 28 17](https://github.com/lovell/sharp/assets/7477825/63aa8551-f7ed-49b9-b33c-ed87583907e6)
