### PR TITLE
types: added missing types for OverlayOptions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1479,8 +1479,14 @@ declare namespace sharp {
         tile?: boolean | undefined;
         /** Set to true to avoid premultipling the image below. Equivalent to the --premultiplied vips option. */
         premultiplied?: boolean | undefined;
+        /** number representing the DPI for vector overlay image. (optional, default 72)*/
+        density?: number | undefined;
         /** Set to true to read all frames/pages of an animated image. (optional, default false) */
         animated?: boolean | undefined;
+        /** see sharp() constructor, (optional, default 'warning') */
+        failOn?: FailOnOptions | undefined;
+        /** see sharp() constructor, (optional, default 268402689) */
+        limitInputPixels?: number | boolean | undefined;
     }
 
     interface TileOptions {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1479,6 +1479,8 @@ declare namespace sharp {
         tile?: boolean | undefined;
         /** Set to true to avoid premultipling the image below. Equivalent to the --premultiplied vips option. */
         premultiplied?: boolean | undefined;
+        /** Set to true to read all frames/pages of an animated image. (optional, default false) */
+        animated?: boolean | undefined;
     }
 
     interface TileOptions {

--- a/test/types/sharp.test-d.ts
+++ b/test/types/sharp.test-d.ts
@@ -680,3 +680,24 @@ sharp(input)
   .keepIccProfile()
   .withIccProfile('filename')
   .withIccProfile('filename', { attach: false });
+
+// Added missing types for OverlayOptions
+// https://github.com/lovell/sharp/pull/4048
+sharp(input).composite([
+  {
+    input: 'image.gif', 
+    animated: true, 
+    limitInputPixels: 536805378, 
+    density: 144, 
+    failOn: "warning"
+  }
+])
+sharp(input).composite([
+  {
+    input: 'image.png',  
+    animated: false,
+    limitInputPixels: 178935126, 
+    density: 72, 
+    failOn: "truncated"
+  }
+])


### PR DESCRIPTION
`animated` property was missing from declaration types, just added it 