### PR TITLE
fix(types): update Channels type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1441,8 +1441,8 @@ declare namespace sharp {
         depth?: 'char' | 'uchar' | 'short' | 'ushort' | 'int' | 'uint' | 'float' | 'complex' | 'double' | 'dpcomplex';
     }
 
-    /** 3 for sRGB, 4 for CMYK */
-    type Channels = 3 | 4;
+    /** 1 for grayscale, 2 for grayscale + alpha, 3 for sRGB, 4 for CMYK or RGBA */
+    type Channels = 1 | 2 | 3 | 4;
 
     interface RGBA {
         r?: number | undefined;


### PR DESCRIPTION
Hey @lovell, improving on the types again


This PR adds 1 and 2 as possible values for the Channels type:

1: The image has only one channel representing grayscale values. Each pixel is stored as a single intensity value, ranging from black to white.

2:  The image could have one channel for grayscale intensity and another channel for alpha (transparency). This is similar to an RGBA image but without the color information, only grayscale (intensity) and alpha.

Possibly there are other reasons for a 2 channel Image but this is the most common one in my experience