### PR TITLE
Update install doc for Electron-builder and Electron-forge

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -233,11 +233,10 @@ custom:
       scripts:
         - npm install --os=linux --cpu=x64 sharp
 ```
-
-### electron
+### electron-builder
 
 Ensure `sharp` is unpacked from the ASAR archive file using the
-[asarUnpack](https://www.electron.build/configuration/configuration.html)
+[asarUnpack](https://www.electron.build/app-builder-lib.interface.platformspecificbuildoptions#asarunpack)
 option.
 
 ```json
@@ -250,6 +249,22 @@ option.
     ]
   }
 }
+```
+
+### electron-forge
+
+Ensure `sharp` is unpacked from the ASAR archive file using the
+[unpack](https://www.electronforge.io/config/plugins/auto-unpack-natives)
+option.
+
+```js
+module.exports = {
+  packagerConfig: {
+    asar: {
+      unpack: "**/node_modules/{sharp,@img}/**/*"
+    }
+  }
+};
 ```
 
 ### vite


### PR DESCRIPTION
Update install documentation for Electron

Renamed the previous Electron section to 'electron-builder' and fixed the broken external link

Added a new section for 'electron-forge' with its own external link to electron-forge documentation and included sharp ASAR configuration. The config for 'electron-forge' is based on part of the resolution in https://github.com/lovell/sharp/issues/4116