### PR TITLE
chore(benchmark): remove simd(true)

### DIFF
--- a/test/bench/parallel.js
+++ b/test/bench/parallel.js
@@ -15,7 +15,6 @@ const width = 720;
 const height = 480;
 
 sharp.concurrency(1);
-sharp.simd(true);
 
 const timer = setInterval(function () {
   console.dir(sharp.counters());

--- a/test/bench/random.js
+++ b/test/bench/random.js
@@ -12,7 +12,6 @@ const sharp = require('../../');
 const fixtures = require('../fixtures');
 
 sharp.cache(false);
-sharp.simd(true);
 
 const min = 320;
 const max = 960;


### PR DESCRIPTION
Since `simd(true)` is the default behavior, these can be removed.

https://sharp.pixelplumbing.com/api-utility#simd