### PR TITLE
CI: Upgrade `uraimo/run-on-arch-action` to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,7 @@ jobs:
             nodejs_version_major: 18
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.run_on_arch }}
           distro: ${{ matrix.distro }}


### PR DESCRIPTION
Upgrade `uraimo/run-on-arch-action` to v3, which includes QEMU 9.2.2 from `tonistiigi/binfmt:latest` that fixes the current CI failure on ppc64le - see:
https://github.com/uraimo/run-on-arch-action/issues/160
https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2689340770 
https://gitlab.com/qemu-project/qemu/-/issues/1913