### PR TITLE
Ensure Yarn PnP hash calculation works with pre-releases

### DIFF
--- a/lib/libvips.js
+++ b/lib/libvips.js
@@ -113,7 +113,9 @@ const sha512 = (s) => createHash('sha512').update(s).digest('hex');
 const yarnLocator = () => {
   try {
     const identHash = sha512(`imgsharp-libvips-${buildPlatformArch()}`);
-    const npmVersion = semverCoerce(optionalDependencies[`@img/sharp-libvips-${buildPlatformArch()}`]).version;
+    const npmVersion = semverCoerce(optionalDependencies[`@img/sharp-libvips-${buildPlatformArch()}`], {
+      includePrerelease: true
+    }).version;
     return sha512(`${identHash}npm:${npmVersion}`).slice(0, 10);
   } catch {}
   return '';

--- a/test/unit/libvips.js
+++ b/test/unit/libvips.js
@@ -179,7 +179,7 @@ describe('libvips binaries', function () {
       process.env.npm_config_arch = 's390x';
       process.env.npm_config_libc = '';
       const locatorHash = libvips.yarnLocator();
-      assert.strictEqual(locatorHash, '9b2ea457de');
+      assert.strictEqual(locatorHash, 'e34c58507a');
       delete process.env.npm_config_platform;
       delete process.env.npm_config_arch;
       delete process.env.npm_config_libc;


### PR DESCRIPTION
Before:
```console
$ ls -1 .yarn/unplugged | grep sharp-libvips-linux-x64
@img-sharp-libvips-linux-x64-npm-1.1.0-rc4-5841416c64
$ yarn node -p "require('sharp/lib/libvips').yarnLocator()"
6e8b62218c
```

After:
```console
$ ls -1 .yarn/unplugged | grep sharp-libvips-linux-x64
@img-sharp-libvips-linux-x64-npm-1.1.0-rc4-5841416c64
$ yarn node -p "require('sharp/lib/libvips').yarnLocator()"
5841416c64
```