### PR TITLE
fix(types): update `autoOrient` type to include undefined

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -971,7 +971,7 @@ declare namespace sharp {
          *
          * Using this option will remove the EXIF `Orientation` tag, if any.
          */
-        autoOrient?: boolean;
+        autoOrient?: boolean | undefined;
         /**
          *  When to abort processing of invalid pixel data, one of (in order of sensitivity):
          *  'none' (least), 'truncated', 'error' or 'warning' (most), highers level imply lower levels, invalid metadata will always abort. (optional, default 'warning')


### PR DESCRIPTION
This PR fixes the following error:

```
node_modules/sharp/lib/index.d.ts(1590,15): error TS2430: Interface 'OverlayOptions' incorrectly extends interface 'SharpOptions'.
  Types of property 'autoOrient' are incompatible.
    Type 'boolean | undefined' is not assignable to type 'boolean'.
      Type 'undefined' is not assignable to type 'boolean'.
```

The bug was introduced in:

- https://github.com/lovell/sharp/issues/4144
- https://github.com/lovell/sharp/pull/4151