### PR TITLE
fix(types): Add missing properties for animated images

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1699,6 +1699,10 @@ declare namespace sharp {
         /** When using the attention crop strategy, the focal point of the cropped region */
         attentionX?: number | undefined;
         attentionY?: number | undefined;
+        /** Number of pages/frames contained within the image, with support for TIFF, HEIF, PDF, animated GIF and animated WebP */
+        pages?: number | undefined;
+        /** Number of pixels high each page in a multi-page image will be. */
+        pageHeight?: number | undefined;
     }
 
     interface AvailableFormatInfo {


### PR DESCRIPTION
Hello! This PR is to add two missing properties to `sharp.OutputInfo` that are present for animated images. Comments are copied from the same properties in `sharp.Metadata`.

The test `Animated GIF round trip` in `test/unit/gif.js` references them ([link](https://github.com/lovell/sharp/blob/5b5dfbad776a2d1aba0739eb52f23b7996821682/test/unit/gif.js#L67-L68)), so it does seem intentional for them to be part of the OutputInfo.

This is my first PR for the project, so please let me know if you need more information from me. 
Thanks for all the hard work on this library!