### PR TITLE
Fix(WebP): Add smartDeblock definition to WebpOptions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1336,6 +1336,8 @@ declare namespace sharp {
         nearLossless?: boolean | undefined;
         /** Use high quality chroma subsampling (optional, default false) */
         smartSubsample?: boolean | undefined;
+        /** Auto-adjust the deblocking filter, slow but can improve low contrast edges (optional, default false) */
+        smartDeblock?: boolean | undefined;
         /** Level of CPU effort to reduce file size, integer 0-6 (optional, default 4) */
         effort?: number | undefined;
         /** Prevent use of animation key frames to minimise file size (slow) (optional, default false) */


### PR DESCRIPTION
This PR proposes a small fix to add the missing typescript definition for the `smartDeblock` option introduced in https://github.com/lovell/sharp/commit/8afec170ed81bc840157ecf5d3ee07ae200ffe33.

I'm not entirely sure yet if I should update [`sharp.test-d.ts`](https://github.com/lovell/sharp/blob/701143afb364c1b618422c59ae955f4084651930/test/types/sharp.test-d.ts). Testing for `WebpOptions` seems scattered and there's no test for all options e.g. `smartSubsample`. But I'm happy to add one if needed.