### PR TITLE
Fixes CVE-2025-48387

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "nyc": "^17.1.0",
     "prebuild": "^13.0.1",
     "semistandard": "^17.0.0",
-    "tar-fs": "^3.0.8",
+    "tar-fs": "^3.0.9",
     "tsd": "^0.32.0"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Bumps `tar-fs` to `^3.0.9`
Ref: https://nvd.nist.gov/vuln/detail/CVE-2025-48387