### PR TITLE
Docs: update link to concurrency API

### DIFF
--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -175,7 +175,7 @@ The default memory allocator on most glibc-based Linux systems
 processes that involve lots of small memory allocations.
 
 For this reason, by default, sharp will limit the use of thread-based
-[concurrency](api-utility#concurrency) when the glibc allocator is
+[concurrency](/api-utility#concurrency) when the glibc allocator is
 detected at runtime.
 
 To help avoid fragmentation and improve performance on these systems,


### PR DESCRIPTION
As a possible follow-up, it may be helpful to mention the `MALLOC_ARENA_MAX=2` env variable here, as well as in [libvips' developer checklist](https://www.libvips.org/API/current/developer-checklist.html#linux-memory-allocator). For context, see the Ruby-focused blog post [here](https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/) and the [in-depth analysis it links to](https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html).

As an aside, https://github.com/jemalloc/jemalloc has been archived, and development now continues at https://github.com/facebook/jemalloc. :man_shrugging: