### PR TITLE
feat: Add withXmp() method for XMP metadata injection

### DIFF
--- a/docs/src/content/docs/api-output.md
+++ b/docs/src/content/docs/api-output.md
@@ -196,6 +196,31 @@ const dataWithMergedExif = await sharp(inputWithExif)
 ```
 
 
+## withXmp
+> withXmp(xmp) ⇒ <code>Sharp</code>
+
+Set XMP metadata in the output image.
+
+
+**Throws**:
+
+- <code>Error</code> Invalid parameters
+
+**Since**: 0.33.0  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| xmp | <code>Buffer</code> | Buffer containing XMP metadata to be embedded in the output image. |
+
+**Example**  
+```js
+const xmpBuffer = Buffer.from('<?xml version="1.0"?><x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:creator><rdf:Seq><rdf:li>John Doe</rdf:li></rdf:Seq></dc:creator></rdf:Description></rdf:RDF></x:xmpmeta>');
+const dataWithXmp = await sharp(input)
+  .withXmp(xmpBuffer)
+  .toBuffer();
+```
+
+
 ## keepIccProfile
 > keepIccProfile() ⇒ <code>Sharp</code>
 

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -2,6 +2,13 @@
 title: Changelog
 ---
   
+## v0.35 - *unreleased*
+
+### Features
+
+* Add support for custom XMP metadata injection via `withMetadata({ xmp: Buffer })`.
+  Allows embedding custom XMP metadata into PNG, JPEG, WebP, and TIFF output images.
+
 ## v0.34 - *hat*
 
 Requires libvips v8.17.0

--- a/lib/constructor.js
+++ b/lib/constructor.js
@@ -304,6 +304,7 @@ const Sharp = function (input, options) {
     withIccProfile: '',
     withExif: {},
     withExifMerge: true,
+    withXmpBuffer: null,
     resolveWithObject: false,
     loop: -1,
     delay: [],

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -419,7 +419,7 @@ declare namespace sharp {
          * @returns {Sharp}
          */
         autoOrient(): Sharp
-  
+
         /**
          * Flip the image about the vertical Y axis. This always occurs after rotation, if any.
          * The use of flip implies the removal of the EXIF Orientation tag, if any.
@@ -729,6 +729,14 @@ declare namespace sharp {
          * @throws {Error} Invalid parameters
          */
         withIccProfile(icc: string, options?: WithIccProfileOptions): Sharp;
+
+        /**
+         * Set XMP metadata in the output image.
+         * @param {Buffer} xmp - Buffer containing XMP metadata to be embedded in the output image.
+         * @returns A sharp instance that can be used to chain operations
+         * @throws {Error} Invalid parameters
+         */
+        withXmp(xmp: Buffer): Sharp;
 
         /**
          * Include all metadata (EXIF, XMP, IPTC) from the input image in the output image.

--- a/lib/output.js
+++ b/lib/output.js
@@ -313,6 +313,35 @@ function withIccProfile (icc, options) {
 }
 
 /**
+ * Set XMP metadata in the output image.
+ *
+ * @since 0.33.0
+ *
+ * @example
+ * const xmpBuffer = Buffer.from('<?xml version="1.0"?><x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:creator><rdf:Seq><rdf:li>John Doe</rdf:li></rdf:Seq></dc:creator></rdf:Description></rdf:RDF></x:xmpmeta>');
+ * const data = await sharp(input)
+ *   .withXmp(xmpBuffer)
+ *   .toBuffer();
+ *
+ * @param {Buffer} xmp Buffer containing XMP metadata to be embedded in the output image.
+ * @returns {Sharp}
+ * @throws {Error} Invalid parameters
+ */
+function withXmp (xmp) {
+  if (xmp === null) {
+    throw is.invalidParameterError('xmp', 'Buffer', xmp);
+  } else if (is.defined(xmp)) {
+    if (is.buffer(xmp)) {
+      this.options.withXmpBuffer = xmp;
+      this.options.keepMetadata |= 0b00010;
+    } else {
+      throw is.invalidParameterError('xmp', 'Buffer', xmp);
+    }
+  }
+  return this;
+}
+
+/**
  * Keep all metadata (EXIF, ICC, XMP, IPTC) from the input image in the output image.
  *
  * The default behaviour, when `keepMetadata` is not used, is to convert to the device-independent
@@ -1576,6 +1605,7 @@ module.exports = function (Sharp) {
     withExifMerge,
     keepIccProfile,
     withIccProfile,
+    withXmp,
     keepMetadata,
     withMetadata,
     toFormat,

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -897,6 +897,15 @@ class PipelineWorker : public Napi::AsyncWorker {
           image.set(s.first.data(), s.second.data());
         }
       }
+      // XMP buffer
+      if ((baton->keepMetadata & VIPS_FOREIGN_KEEP_XMP)
+        && baton->withXmpBuffer != nullptr && baton->withXmpBufferLength > 0) {
+        image = image.copy();
+        image.set(VIPS_META_XMP_NAME, reinterpret_cast<VipsCallbackFn>(vips_area_free_cb),
+                  baton->withXmpBuffer, baton->withXmpBufferLength);
+        // VIPS now owns the memory and will free it via the callback
+        baton->withXmpBuffer = nullptr;  // Prevent double-free in destructor
+      }
 
       // Number of channels used in output image
       baton->channels = image.bands();
@@ -1393,6 +1402,10 @@ class PipelineWorker : public Napi::AsyncWorker {
     for (sharp::InputDescriptor *input : baton->join) {
       delete input;
     }
+    // Free XMP buffer if still allocated
+    if (baton->withXmpBuffer != nullptr) {
+      g_free(baton->withXmpBuffer);
+    }
     delete baton;
 
     // Decrement processing task counter
@@ -1727,6 +1740,18 @@ Napi::Value pipeline(const Napi::CallbackInfo& info) {
     }
   }
   baton->withExifMerge = sharp::AttrAsBool(options, "withExifMerge");
+  // XMP buffer
+  if (sharp::HasAttr(options, "withXmpBuffer")) {
+    Napi::Value xmpValue = options.Get("withXmpBuffer");
+    if (xmpValue.IsBuffer()) {
+      Napi::Buffer<char> withXmpBuffer = xmpValue.As<Napi::Buffer<char>>();
+      baton->withXmpBufferLength = withXmpBuffer.Length();
+      if (baton->withXmpBufferLength > 0) {
+        baton->withXmpBuffer = g_malloc(baton->withXmpBufferLength);
+        memcpy(baton->withXmpBuffer, withXmpBuffer.Data(), baton->withXmpBufferLength);
+      }
+    }
+  }
   baton->timeoutSeconds = sharp::AttrAsUint32(options, "timeoutSeconds");
   baton->loop = sharp::AttrAsUint32(options, "loop");
   baton->delay = sharp::AttrAsInt32Vector(options, "delay");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -202,6 +202,8 @@ struct PipelineBaton {
   std::string withIccProfile;
   std::unordered_map<std::string, std::string> withExif;
   bool withExifMerge;
+  void *withXmpBuffer;
+  size_t withXmpBufferLength;
   int timeoutSeconds;
   std::vector<double> convKernel;
   int convKernelWidth;
@@ -373,6 +375,8 @@ struct PipelineBaton {
     withMetadataOrientation(-1),
     withMetadataDensity(0.0),
     withExifMerge(true),
+    withXmpBuffer(nullptr),
+    withXmpBufferLength(0),
     timeoutSeconds(0),
     convKernelWidth(0),
     convKernelHeight(0),


### PR DESCRIPTION
partially resolves #4143

- Add withXmp(xmpBuffer) method to embed custom XMP metadata in output images
- Include parameter validation for non-Buffer inputs
- Add tests
- Update API documentation