### PR TITLE
Update to color ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "vips"
   ],
   "dependencies": {
-    "color": "^4.2.3",
+    "color": "^5.0.1",
     "detect-libc": "^2.0.4",
     "semver": "^7.7.2"
   },


### PR DESCRIPTION
Color had transitive dependencies on is-arrayish and simple-swizzle, two recently compromised packages.

As simple-swizzle is no longer recommended (and never really was) this seems like a good time to update to the latest version of color which eliminates those dependencies