### PR TITLE
Add rpath for sharp-libvips in binding.gyp

### DIFF
--- a/src/binding.gyp
+++ b/src/binding.gyp
@@ -168,6 +168,7 @@
                 # Ensure runtime linking is relative to sharp.node
                 '-Wl,-rpath,\'@loader_path/../../sharp-libvips-<(platform_and_arch)/lib\'',
                 '-Wl,-rpath,\'@loader_path/../../../sharp-libvips-<(platform_and_arch)/<(sharp_libvips_version)/lib\'',
+                '-Wl,-rpath,\'@loader_path/../node_modules/@img/sharp-libvips-<(platform_and_arch)/lib\'',
                 '-Wl,-rpath,\'@loader_path/../../node_modules/@img/sharp-libvips-<(platform_and_arch)/lib\'',
                 '-Wl,-rpath,\'@loader_path/../../../node_modules/@img/sharp-libvips-<(platform_and_arch)/lib\'',
                 '-Wl,-rpath,\'@loader_path/../../../../../@img-sharp-libvips-<(platform_and_arch)-npm-<(sharp_libvips_version)-<(sharp_libvips_yarn_locator)/node_modules/@img/sharp-libvips-<(platform_and_arch)/lib\''


### PR DESCRIPTION
The rpath setting lists the path in which the linker should try to load the required dylibs. Paths are relative to the library, so with the current setting of:

```
'-Wl,-rpath,\'@loader_path/../../node_modules/@img/sharp-libvips-<(platform_and_arch)/lib\'',
'-Wl,-rpath,\'@loader_path/../../../node_modules/@img/sharp-libvips-<(platform_and_arch)/lib\'',
```

A library located in `node_modules/pkg/lib/sharp/lib.node` will try to find the libvips binary in the hoisted `node_modules/@img/sharp-libvips-*/lib` path, but not in the non-hoisted path `node_modules/pkg/node_modules/@img/sharp-libvips-*/lib`.

This PR adds the non-hoisted path to the rpath list so it properly locates the file when it's found as a direct dependency.

We stumbled upon this issue while attempting to solve in Yarn the root cause why you [rely on Yarn-specific code](https://github.com/lovell/sharp/blob/45f871790057017a42647d3a47f925a84541c9c5/src/binding.gyp#L173).