### PR TITLE
Docs: libvips manages its own thread pool

### DIFF
--- a/docs/src/content/docs/performance.md
+++ b/docs/src/content/docs/performance.md
@@ -17,8 +17,8 @@ before the Node.js process starts to increase the thread pool size.
 export UV_THREADPOOL_SIZE="$(lscpu -p | egrep -v "^#" | sort -u -t, -k 2,4 | wc -l)"
 ```
 
-libvips uses a glib-managed thread pool to avoid the overhead of spawning new threads.
-The size of the shared thread pool will grow on demand and shrink when idle.
+libvips uses a shared thread pool to avoid the overhead of spawning new threads.
+The size of this thread pool will grow on demand and shrink when idle.
 
 The default number of threads used to concurrently process each image is the same as the number of CPU cores,
 except when using glibc-based Linux without jemalloc, where the default is `1` to help reduce memory fragmentation.


### PR DESCRIPTION
Since version 8.14, libvips no longer uses [`GThreadPool`](https://docs.gtk.org/glib/struct.ThreadPool.html).
https://www.libvips.org/2022/12/22/What's-new-in-8.14.html#faster-threading