### PR TITLE
Tests: migrate text suite to async

### DIFF
--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -39,7 +39,7 @@ describe('Text to image', function () {
     assert.ok(info.textAutofitDpi > 0);
   });
 
-  it('text with width and height', function (t, done) {
+  it('text with width and height', async function (t) {
     const output = fixtures.path('output.text-width-height.png');
     const text = sharp({
       text: {
@@ -51,18 +51,15 @@ describe('Text to image', function () {
     if (!sharp.versions.pango) {
       return t.skip();
     }
-    text.toFile(output, function (err, info) {
-      if (err) throw err;
-      assert.strictEqual('png', info.format);
-      assert.strictEqual(3, info.channels);
-      assert.ok(inRange(info.width, 400, 600), `Actual width ${info.width}`);
-      assert.ok(inRange(info.height, 290, 500), `Actual height ${info.height}`);
-      assert.ok(inRange(info.textAutofitDpi, 900, 1300), `Actual textAutofitDpi ${info.textAutofitDpi}`);
-      done();
-    });
+    const info = await text.toFile(output);
+    assert.strictEqual('png', info.format);
+    assert.strictEqual(3, info.channels);
+    assert.ok(inRange(info.width, 400, 600), `Actual width ${info.width}`);
+    assert.ok(inRange(info.height, 290, 500), `Actual height ${info.height}`);
+    assert.ok(inRange(info.textAutofitDpi, 900, 1300), `Actual textAutofitDpi ${info.textAutofitDpi}`);
   });
 
-  it('text with dpi', function (t, done) {
+  it('text with dpi', async function (t) {
     const output = fixtures.path('output.text-dpi.png');
     const dpi = 300;
     const text = sharp({
@@ -74,18 +71,13 @@ describe('Text to image', function () {
     if (!sharp.versions.pango) {
       return t.skip();
     }
-    text.toFile(output, function (err, info) {
-      if (err) throw err;
-      assert.strictEqual('png', info.format);
-      sharp(output).metadata(function (err, metadata) {
-        if (err) throw err;
-        assert.strictEqual(dpi, metadata.density);
-        done();
-      });
-    });
+    const info = await text.toFile(output);
+    assert.strictEqual('png', info.format);
+    const metadata = await sharp(output).metadata();
+    assert.strictEqual(dpi, metadata.density);
   });
 
-  it('text with color and pango markup', function (t, done) {
+  it('text with color and pango markup', async function (t) {
     const output = fixtures.path('output.text-color-pango.png');
     const dpi = 300;
     const text = sharp({
@@ -98,21 +90,16 @@ describe('Text to image', function () {
     if (!sharp.versions.pango) {
       return t.skip();
     }
-    text.toFile(output, function (err, info) {
-      if (err) throw err;
-      assert.strictEqual('png', info.format);
-      assert.strictEqual(4, info.channels);
-      sharp(output).metadata(function (err, metadata) {
-        if (err) throw err;
-        assert.strictEqual(dpi, metadata.density);
-        assert.strictEqual('uchar', metadata.depth);
-        assert.strictEqual(true, metadata.hasAlpha);
-        done();
-      });
-    });
+    const info = await text.toFile(output);
+    assert.strictEqual('png', info.format);
+    assert.strictEqual(4, info.channels);
+    const metadata = await sharp(output).metadata();
+    assert.strictEqual(dpi, metadata.density);
+    assert.strictEqual('uchar', metadata.depth);
+    assert.strictEqual(true, metadata.hasAlpha);
   });
 
-  it('text with font', function (t, done) {
+  it('text with font', async function (t) {
     const output = fixtures.path('output.text-with-font.png');
     const text = sharp({
       text: {
@@ -123,17 +110,14 @@ describe('Text to image', function () {
     if (!sharp.versions.pango) {
       return t.skip();
     }
-    text.toFile(output, function (err, info) {
-      if (err) throw err;
-      assert.strictEqual('png', info.format);
-      assert.strictEqual(3, info.channels);
-      assert.ok(info.width > 30);
-      assert.ok(info.height > 10);
-      done();
-    });
+    const info = await text.toFile(output);
+    assert.strictEqual('png', info.format);
+    assert.strictEqual(3, info.channels);
+    assert.ok(info.width > 30);
+    assert.ok(info.height > 10);
   });
 
-  it('text with justify and composite', function (t, done) {
+  it('text with justify and composite', async function (t) {
     const output = fixtures.path('output.text-composite.png');
     const width = 500;
     const dpi = 300;
@@ -167,20 +151,15 @@ describe('Text to image', function () {
     if (!sharp.versions.pango) {
       return t.skip();
     }
-    text.toFile(output, function (err, info) {
-      if (err) throw err;
-      assert.strictEqual('png', info.format);
-      assert.strictEqual(4, info.channels);
-      assert.strictEqual(width, info.width);
-      assert.strictEqual(true, info.premultiplied);
-      sharp(output).metadata(function (err, metadata) {
-        if (err) throw err;
-        assert.strictEqual('srgb', metadata.space);
-        assert.strictEqual('uchar', metadata.depth);
-        assert.strictEqual(true, metadata.hasAlpha);
-        done();
-      });
-    });
+    const info = await text.toFile(output);
+    assert.strictEqual('png', info.format);
+    assert.strictEqual(4, info.channels);
+    assert.strictEqual(width, info.width);
+    assert.strictEqual(true, info.premultiplied);
+    const metadata = await sharp(output).metadata();
+    assert.strictEqual('srgb', metadata.space);
+    assert.strictEqual('uchar', metadata.depth);
+    assert.strictEqual(true, metadata.hasAlpha);
   });
 
   it('bad text input', function () {


### PR DESCRIPTION
After migrating to the Node.js native test runner, I found that several text-related tests were timing out at 60 seconds when using a globally-installed libvips.

<details>
  <summary>Details</summary>

```console
...
▶ Text to image
  ﹣ text with default values (2.558585ms) # SKIP
  ﹣ text with width and height (60000.243835ms) # SKIP
  ﹣ text with dpi (60006.379163ms) # SKIP
  ﹣ text with color and pango markup (60001.064501ms) # SKIP
  ﹣ text with font (60005.997102ms) # SKIP
  ﹣ text with justify and composite (60000.452162ms) # SKIP
  ✔ bad text input (0.401089ms)
  ✔ fontfile input (0.14158ms)
  ✔ bad font input (0.108329ms)
  ✔ bad fontfile input (0.10318ms)
  ✔ invalid width (0.35421ms)
  ✔ invalid height (0.229579ms)
  ✔ bad align input (0.09351ms)
  ✔ bad justify input (0.09659ms)
  ✔ invalid dpi (0.20053ms)
  ✔ bad rgba input (0.089959ms)
  ✔ invalid spacing (0.708499ms)
  ✔ only height or dpi not both (0.09129ms)
  ✔ valid wrap throws (0.09076ms)
  ✔ invalid wrap throws (0.14912ms)
...

test at test/unit/text.js:42:3
﹣ text with width and height (60000.243835ms) # SKIP
  'test timed out after 60000ms'

test at test/unit/text.js:65:3
﹣ text with dpi (60006.379163ms) # SKIP
  'test timed out after 60000ms'

test at test/unit/text.js:88:3
﹣ text with color and pango markup (60001.064501ms) # SKIP
  'test timed out after 60000ms'

test at test/unit/text.js:115:3
﹣ text with font (60005.997102ms) # SKIP
  'test timed out after 60000ms'

test at test/unit/text.js:136:3
﹣ text with justify and composite (60000.452162ms) # SKIP
  'test timed out after 60000ms'
```
</details>

It appears that, unlike Mocha, the Node.js test runner doesn't automatically call `done()` when `t.skip()` is called.

This can also be fixed by doing the following:

<details>
  <summary>Details</summary>

```diff
--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -49,7 +49,8 @@ describe('Text to image', function () {
       }
     });
     if (!sharp.versions.pango) {
-      return t.skip();
+      t.skip();
+      return done();
     }
     text.toFile(output, function (err, info) {
       if (err) throw err;
@@ -72,7 +73,8 @@ describe('Text to image', function () {
       }
     });
     if (!sharp.versions.pango) {
-      return t.skip();
+      t.skip();
+      return done();
     }
     text.toFile(output, function (err, info) {
       if (err) throw err;
@@ -96,7 +98,8 @@ describe('Text to image', function () {
       }
     });
     if (!sharp.versions.pango) {
-      return t.skip();
+      t.skip();
+      return done();
     }
     text.toFile(output, function (err, info) {
       if (err) throw err;
@@ -121,7 +124,8 @@ describe('Text to image', function () {
       }
     });
     if (!sharp.versions.pango) {
-      return t.skip();
+      t.skip();
+      return done();
     }
     text.toFile(output, function (err, info) {
       if (err) throw err;
@@ -165,7 +169,8 @@ describe('Text to image', function () {
         top: 250
       }]);
     if (!sharp.versions.pango) {
-      return t.skip();
+      t.skip();
+      return done();
     }
     text.toFile(output, function (err, info) {
       if (err) throw err;
```
</details>

But this approach is probably a bit neater.