### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/src/binding.gyp
+++ b/src/binding.gyp
@@ -120,7 +120,7 @@
     'conditions': [
       ['use_global_libvips == "true"', {
         # Use pkg-config for include and lib
-        'include_dirs': ['<!@(PKG_CONFIG_PATH="<(pkg_config_path)" pkg-config --cflags-only-I vips-cpp vips glib-2.0 | sed s\/-I//g)'],
+        'include_dirs': ['<!@(PKG_CONFIG_PATH="<(pkg_config_path)" pkg-config --cflags-only-I vips-cpp vips glib-2.0 | sed s/-I//g)'],
         'libraries': ['<!@(PKG_CONFIG_PATH="<(pkg_config_path)" pkg-config --libs vips-cpp)'],
         'defines': [
           'SHARP_USE_GLOBAL_LIBVIPS'


### PR DESCRIPTION
Trying to get rid of this syntax warning:

https://github.com/lovell/sharp/actions/runs/19138347662/job/54696283442#step:9:48