### PR TITLE
Tests: fix JP2 suite with global libvips

### DIFF
--- a/test/unit/jp2.js
+++ b/test/unit/jp2.js
@@ -45,11 +45,11 @@ describe('JP2 output', () => {
           assert.strictEqual('png', info.format);
           assert.strictEqual(8, info.width);
           assert.strictEqual(15, info.height);
-          assert.strictEqual(4, info.channels);
+          assert.strictEqual(3, info.channels);
         });
     });
 
-    it('JP2 quality', (done) => {
+    it('JP2 quality', (_t, done) => {
       sharp(fixtures.inputJp2)
         .resize(320, 240)
         .jp2({ quality: 70 })
@@ -65,7 +65,7 @@ describe('JP2 output', () => {
         });
     });
 
-    it('Without chroma subsampling generates larger file', (done) => {
+    it('Without chroma subsampling generates larger file', (_t, done) => {
       // First generate with chroma subsampling (default)
       sharp(fixtures.inputJp2)
         .resize(320, 240)
@@ -111,7 +111,7 @@ describe('JP2 output', () => {
     it('Invalid JP2 chromaSubsampling value throws error', () => {
       assert.throws(
         () => sharp().jp2({ chromaSubsampling: '4:2:2' }),
-        /Expected one of 4:2:0, 4:4:4 but received 4:2:2 of type string/
+        /Expected one of: 4:2:0, 4:4:4 for chromaSubsampling but received 4:2:2 of type string/
       );
     });
   }


### PR DESCRIPTION
<details>
  <summary>Details</summary>

```
[...]

✖ JP2 output (29.6819ms)
ℹ Error: Test "JP2 Buffer to PNG Buffer" at test/unit/jp2.js:37:5 generated asynchronous activity after the test ended. This activity created the error "AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

4 !== 3
" and would have caused the test to fail, but instead triggered an unhandledRejection event.
ℹ Error: Test "Without chroma subsampling generates larger file" at test/unit/jp2.js:68:5 generated asynchronous activity after the test ended. This activity created the error "TypeError: done is not a function" and would have caused the test to fail, but instead triggered an uncaughtException event.
ℹ Error: Test "JP2 quality" at test/unit/jp2.js:52:5 generated asynchronous activity after the test ended. This activity created the error "TypeError: done is not a function" and would have caused the test to fail, but instead triggered an uncaughtException event.

[...]

✖ failing tests:

test at test/unit/jp2.js:111:5
✖ Invalid JP2 chromaSubsampling value throws error (1.115768ms)
  AssertionError [ERR_ASSERTION]: The input did not match the regular expression /Expected one of 4:2:0, 4:4:4 but received 4:2:2 of type string/. Input:
  
  'Error: Expected one of: 4:2:0, 4:4:4 for chromaSubsampling but received 4:2:2 of type string'
```
</details>

