### PR TITLE
Fix #4475: Correct FormatEnum type keys jp2→jp2k and v→vips

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1923,7 +1923,7 @@ declare namespace sharp {
         input: AvailableFormatInfo;
         jpeg: AvailableFormatInfo;
         jpg: AvailableFormatInfo;
-        jp2: AvailableFormatInfo;
+        jp2k: AvailableFormatInfo;
         jxl: AvailableFormatInfo;
         magick: AvailableFormatInfo;
         openslide: AvailableFormatInfo;
@@ -1935,7 +1935,7 @@ declare namespace sharp {
         svg: AvailableFormatInfo;
         tiff: AvailableFormatInfo;
         tif: AvailableFormatInfo;
-        v: AvailableFormatInfo;
+        vips: AvailableFormatInfo;
         webp: AvailableFormatInfo;
     }
 

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -142,6 +142,16 @@ describe('Utilities', () => {
     it('output alias', () => {
       assert.deepStrictEqual(['jpe', 'jpg'], sharp.format.jpeg.output.alias);
     });
+    it('uses jp2k as format key, not jp2 (#4475)', () => {
+      assert.strictEqual('object', typeof sharp.format.jp2k);
+      assert.strictEqual('jp2k', sharp.format.jp2k.id);
+      assert.strictEqual(undefined, sharp.format.jp2);
+    });
+    it('uses vips as format key, not v (#4475)', () => {
+      assert.strictEqual('object', typeof sharp.format.vips);
+      assert.strictEqual('vips', sharp.format.vips.id);
+      assert.strictEqual(undefined, sharp.format.v);
+    });
   });
 
   describe('Versions', () => {


### PR DESCRIPTION
The `FormatEnum` TypeScript interface declared `jp2` and `v` as keys, but the runtime `sharp.format` object uses `jp2k` and `vips` (matching libvips internal format identifiers).

## Changes

- `lib/index.d.ts`: Renamed `jp2` → `jp2k` and `v` → `vips` in `FormatEnum` interface
- `test/unit/util.js`: Added two test cases verifying the correct keys exist and the old incorrect keys are undefined

## Test

Added `uses jp2k as format key, not jp2 (#4475)` and `uses vips as format key, not v (#4475)` tests that:
1. Verify `sharp.format.jp2k` exists with correct id
2. Verify `sharp.format.vips` exists with correct id  
3. Verify `sharp.format.jp2` and `sharp.format.v` are undefined

Full test suite passes on macOS ARM (Apple Silicon).