### PR TITLE
Remove `-sNODEJS_CATCH_REJECTION=0` linker flag

### DIFF
--- a/src/emscripten/common.gypi
+++ b/src/emscripten/common.gypi
@@ -18,8 +18,7 @@
       '--js-library=<!(node -p "require(\'emnapi\').js_library")',
       '-sAUTO_JS_LIBRARIES=0',
       '-sAUTO_NATIVE_LIBRARIES=0',
-      '-sDEFAULT_TO_CXX=0',
-      '-sNODEJS_CATCH_REJECTION=0'
+      '-sDEFAULT_TO_CXX=0'
     ],
     'defines': [
       '__STDC_FORMAT_MACROS',


### PR DESCRIPTION
Removed since Emscripten 5.0.2, see commit:
emscripten-core/emscripten@84078260c70c601172e290d4c0046c2a04d59636