### PR TITLE
Use `brew --prefix` to get brew package config path for install script

### DIFF
--- a/lib/libvips.js
+++ b/lib/libvips.js
@@ -144,17 +144,24 @@ const globalLibvipsVersion = () => {
   }
 };
 
+const getBrewPkgConfigPath = () => {
+  try {
+    const brewPrefix = (spawnSync('brew', ['--prefix'], { encoding: 'utf8' }).stdout || '').trim();
+    if (brewPrefix) {
+      return `${brewPrefix}/lib/pkgconfig`;
+    }
+  } catch (_err) {
+    // ignore
+  }
+  return undefined;
+};
+
 /* node:coverage enable */
 
 const pkgConfigPath = () => {
   if (process.platform !== 'win32') {
-    /* node:coverage ignore next 4 */
-    const brewPkgConfigPath = spawnSync(
-      'which brew >/dev/null 2>&1 && brew environment --plain | grep PKG_CONFIG_LIBDIR | cut -d" " -f2',
-      spawnSyncOptions
-    ).stdout || '';
     return [
-      brewPkgConfigPath.trim(),
+      getBrewPkgConfigPath(),
       process.env.PKG_CONFIG_PATH,
       '/usr/local/lib/pkgconfig',
       '/usr/lib/pkgconfig',


### PR DESCRIPTION
We noticed the Bun package manager is excluding the install script for your package because it is slow.

https://github.com/oven-sh/bun/blob/a305e99af5d9dbe74ffabfa5a3c0cfdf815ac71a/src/install/postinstall_optimizer.zig#L14-L19

In Deno we were looking into making a similar optimization, but we don't believe it would be good to override your preferences just so we can do better on an install benchmark.

I was looking at the code and I believe that it should actually get the value from `brew --prefix` then `./lib/pkgconfig`. I'm not sure though. It is much faster to do this on my machine.

```
% hyperfine --warmup 5 "brew --prefix" "brew environment --plain"
Benchmark 1: brew --prefix
  Time (mean ± σ):      22.9 ms ±   1.6 ms    [User: 8.3 ms, System: 8.8 ms]
  Range (min … max):    18.8 ms …  29.1 ms    120 runs
 
Benchmark 2: brew environment --plain
  Time (mean ± σ):     789.2 ms ±  65.3 ms    [User: 209.1 ms, System: 139.0 ms]
  Range (min … max):   714.9 ms … 884.1 ms    10 runs
 
Summary
  brew --prefix ran
   34.41 ± 3.68 times faster than brew environment --plain
```