### PR TITLE
fix: validate raw buffer size before VImage::new_from_memory

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -215,6 +215,17 @@ function _createInputDescriptor (input, inputOptions, containerOptions) {
             inputDescriptor.rawDepth = 'uchar';
             break;
         }
+        // Validate buffer size is sufficient for declared raw dimensions
+        if (is.buffer(inputDescriptor.buffer) || is.typedArray(inputDescriptor.buffer)) {
+          const bytesPerPixel = { uchar: 1, char: 1, ushort: 2, short: 2, uint: 4, int: 4, float: 4, double: 8 };
+          const expectedBytes = inputOptions.raw.width * inputOptions.raw.height * inputOptions.raw.channels *
+            (bytesPerPixel[inputDescriptor.rawDepth] || 1);
+          if (inputDescriptor.buffer.length < expectedBytes) {
+            throw new Error(
+              `Expected buffer length of at least ${expectedBytes} for raw input, received ${inputDescriptor.buffer.length}`
+            );
+          }
+        }
       } else {
         throw new Error('Expected width, height and channels for raw pixel input');
       }

--- a/src/common.cc
+++ b/src/common.cc
@@ -455,6 +455,14 @@ namespace sharp {
     if (descriptor->isBuffer) {
       if (descriptor->rawChannels > 0) {
         // Raw, uncompressed pixel data
+        size_t const expectedLength = static_cast<size_t>(descriptor->rawWidth) *
+          static_cast<size_t>(descriptor->rawHeight) *
+          static_cast<size_t>(descriptor->rawChannels) *
+          static_cast<size_t>(vips_format_sizeof(descriptor->rawDepth));
+        if (descriptor->bufferLength < expectedLength) {
+          throw vips::VError("Raw buffer too small for declared dimensions "
+            "(expected at least %zu bytes, received %zu)", expectedLength, descriptor->bufferLength);
+        }
         bool const is8bit = vips_band_format_is8bit(descriptor->rawDepth);
         image = VImage::new_from_memory(descriptor->buffer, descriptor->bufferLength,
           descriptor->rawWidth, descriptor->rawHeight, descriptor->rawChannels, descriptor->rawDepth);


### PR DESCRIPTION
## Summary

Fixes #4518 — out-of-bounds heap read via raw buffer size mismatch.

When using `sharp(buffer, { raw: { width, height, channels } })`, neither the JS nor C++ layer validated that the provided buffer was large enough for the declared dimensions. A small buffer with large declared dimensions causes `VImage::new_from_memory()` to read past the buffer boundary, leading to heap data leakage or a segfault.

## Changes

- **`lib/input.js`**: After determining `rawDepth` from the typed array constructor, validate that `buffer.length >= width * height * channels * bytesPerDepth`. Throws a descriptive `Error` if the buffer is too small.
- **`src/common.cc`**: Defense-in-depth check using `vips_format_sizeof()` before calling `VImage::new_from_memory()`. Throws `vips::VError` if the buffer is undersized.

## Reproduction (before fix)

\`\`\`js
const sharp = require('sharp');
const small = Buffer.alloc(10);
// Reads 29,990 bytes past buffer boundary
await sharp(small, { raw: { width: 100, height: 100, channels: 3 } }).toBuffer();
\`\`\`

After this fix, the above throws: \`Error: Expected buffer length of at least 30000 for raw input, received 10\`

## Test plan

- [ ] Verify the JS layer rejects undersized buffers with a clear error message
- [ ] Verify valid raw buffers continue to work as expected
- [ ] Verify the C++ layer catches any cases that bypass the JS validation
- [ ] Run \`npm test\` (requires native build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)