### PR TITLE
Docs: bump astro to latest version 6.3.1

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -74,7 +74,7 @@ export default defineConfig({
         {
           label: 'Changelog',
           collapsed: true,
-          autogenerate: { directory: 'changelog' }
+          items: [{autogenerate: { directory: 'changelog' } }],
         }
       ],
       social: [

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,8 +11,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.36.2",
-    "astro": "^5.15.3",
-    "starlight-auto-sidebar": "^0.1.3"
+    "@astrojs/starlight": "^0.39.1",
+    "astro": "^6.3.1",
+    "starlight-auto-sidebar": "^0.4.0"
   }
 }


### PR DESCRIPTION
This PR bumps astro used to generate docuemntation to latest version 6.3.1.