### PR TITLE
type-check density option before range validation

### DIFF
--- a/lib/input.mjs
+++ b/lib/input.mjs
@@ -125,7 +125,7 @@ function _createInputDescriptor (input, inputOptions, containerOptions) {
     }
     // Density
     if (is.defined(inputOptions.density)) {
-      if (is.inRange(inputOptions.density, 1, 100000)) {
+      if (is.number(inputOptions.density) && is.inRange(inputOptions.density, 1, 100000)) {
         inputDescriptor.density = inputOptions.density;
       } else {
         throw is.invalidParameterError('density', 'number between 1 and 100000', inputOptions.density);

--- a/test/unit/io.js
+++ b/test/unit/io.js
@@ -901,6 +901,20 @@ suite('Input/output', () => {
         /Expected number between 1 and 100000 for density but received zoinks of type string/
       );
     });
+    test('Invalid density: numeric string', (t) => {
+      t.plan(1);
+      t.assert.throws(
+        () => sharp({ density: '50' }),
+        /Expected number between 1 and 100000 for density but received 50 of type string/
+      );
+    });
+    test('Invalid density: array', (t) => {
+      t.plan(1);
+      t.assert.throws(
+        () => sharp({ density: [50] }),
+        /Expected number between 1 and 100000 for density but received 50 of type object/
+      );
+    });
     test('Invalid ignoreIcc: string', (t) => {
       t.plan(1);
       t.assert.throws(


### PR DESCRIPTION
**Missing type guard on the density option**
Unlike every other numeric input option, `density` is range-checked with `is.inRange` but never type-checked, so a numeric string or single-element array (e.g. `'50'` or `[50]`) slips through to the native layer instead of being rejected. Added an `is.number` guard to match the sibling checks and the error message that already promises a number.