### PR TITLE
Docs: Remove ARMv8.4 CPU caveat for Windows ARM64

### DIFF
--- a/docs/src/content/docs/api-output.md
+++ b/docs/src/content/docs/api-output.md
@@ -789,8 +789,6 @@ Use these AVIF options for output image.
 
 AVIF image sequences are not supported.
 
-When using Windows ARM64, this feature requires a CPU with ARM64v8.4 or later.
-
 
 **Throws**:
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -51,7 +51,7 @@ Ready-compiled sharp and libvips binaries are provided for use on the most commo
 * Linux x64 (glibc >= 2.28, musl >= 1.2.5, CPU with SSE4.2)
 * Windows x64
 * Windows x86 (deprecated, Node.js 20 only)
-* Windows ARM64 (CPU with ARMv8.4 required for all features)
+* Windows ARM64
 * FreeBSD (WebAssembly)
 
 This provides support for the

--- a/lib/output.mjs
+++ b/lib/output.mjs
@@ -1207,8 +1207,6 @@ function tiff (options) {
  *
  * AVIF image sequences are not supported.
  *
- * When using Windows ARM64, this feature requires a CPU with ARM64v8.4 or later.
- *
  * @example
  * const data = await sharp(input)
  *   .avif({ effort: 2 })


### PR DESCRIPTION
This partially reverts commit c4d6aec48c55227b28425d8f7e46ff1373861ba9.

---

`-DCONFIG_RUNTIME_CPU_DETECT=0` was removed in commit https://github.com/libvips/build-win64-mxe/commit/e41f5c7873a1cb3fa0b30ee40afcd7ac82501798 because LLVM now supports SVE instructions. As a result, AVIF saving also works on CPUs older than ARMv8.4. I confirmed this on my Raspberry Pi 4B w/ 4GB ram.

Context: https://github.com/lovell/sharp-libvips/issues/238#issuecomment-2891018772.