### PR TITLE
Docs: fix link in changelog

### DIFF
--- a/docs/src/content/docs/changelog/v0.35.1.md
+++ b/docs/src/content/docs/changelog/v0.35.1.md
@@ -4,7 +4,7 @@ slug: changelog/v0.35.1
 ---
 
 * TypeScript: Ensure type definitions are published
-  [#4537](github.com/lovell/sharp/issues/4537)
+  [#4537](https://github.com/lovell/sharp/issues/4537)
 
 * WebAssembly: Ensure wrapper file is published.
   [#4538](https://github.com/lovell/sharp/issues/4538)


### PR DESCRIPTION
As noticed in https://github.com/lovell/sharp/releases/tag/v0.35.1-rc.0.