### PR TITLE
type-check gif effort as integer before range validation

### DIFF
--- a/lib/output.mjs
+++ b/lib/output.mjs
@@ -929,7 +929,7 @@ function gif (options) {
       }
     }
     if (is.defined(options.effort)) {
-      if (is.number(options.effort) && is.inRange(options.effort, 1, 10)) {
+      if (is.integer(options.effort) && is.inRange(options.effort, 1, 10)) {
         this.options.gifEffort = options.effort;
       } else {
         throw is.invalidParameterError('effort', 'integer between 1 and 10', options.effort);

--- a/test/unit/gif.js
+++ b/test/unit/gif.js
@@ -151,10 +151,14 @@ suite('GIF input', () => {
   });
 
   test('invalid effort throws', (t) => {
-    t.plan(2);
+    t.plan(3);
     t.assert.throws(() => {
       sharp().gif({ effort: 0 });
     });
+    t.assert.throws(
+      () => sharp().gif({ effort: 7.5 }),
+      /Expected integer between 1 and 10 for effort but received 7.5 of type number/
+    );
     t.assert.throws(() => {
       sharp().gif({ effort: 'fail' });
     });


### PR DESCRIPTION
**Non-integer effort accepted by gif output**
The gif `effort` option is guarded with `is.number`, so a fractional value such as `7.5` passes the range check and is then silently truncated when read as a uint32 by the native layer, unlike the png, webp, heif and jxl effort options which all use `is.integer`. Swapped in `is.integer` so the guard matches the documented contract and the existing error message, which both promise an integer.