### PR TITLE
validate recomb matrix entries are numbers

### DIFF
--- a/lib/operation.mjs
+++ b/lib/operation.mjs
@@ -862,9 +862,12 @@ function recomb (inputMatrix) {
   if (inputMatrix.length !== 3 && inputMatrix.length !== 4) {
     throw is.invalidParameterError('inputMatrix', '3x3 or 4x4 array', inputMatrix.length);
   }
-  const recombMatrix = inputMatrix.flat().map(Number);
+  const recombMatrix = inputMatrix.flat();
   if (recombMatrix.length !== 9 && recombMatrix.length !== 16) {
     throw is.invalidParameterError('inputMatrix', 'cardinality of 9 or 16', recombMatrix.length);
+  }
+  if (!recombMatrix.every(is.number)) {
+    throw is.invalidParameterError('inputMatrix', 'array of numbers', recombMatrix);
   }
   this.options.recombMatrix = recombMatrix;
   return this;

--- a/test/unit/recomb.js
+++ b/test/unit/recomb.js
@@ -164,5 +164,11 @@ suite('Recomb', () => {
         sharp(fixtures.inputJpg).recomb([[1, 2, 3, 4], [5, 6, 7, 8]]);
       });
     });
+    test('non-numeric entries', (t) => {
+      t.plan(1);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg).recomb([['a', 'b', 'c'], [1, 2, 3], [4, 5, 6]]);
+      });
+    });
   });
 });


### PR DESCRIPTION
**Inconsistent type checking in recomb**
The recombination matrix is flattened and passed through `map(Number)`, so non-numeric entries are silently coerced rather than rejected: a stray string becomes `NaN` while `true` and `null` turn into `1` and `0` before they reach the native matrix. The sibling `affine` and `linear` operations already guard their input with `is.number`, so this should keep the behaviour consistent and surface the mistake to the caller instead of producing a quietly wrong result.