### PR TITLE
docs: update `install` life cycle script removal

### DIFF
--- a/docs/src/content/docs/changelog/v0.35.0.md
+++ b/docs/src/content/docs/changelog/v0.35.0.md
@@ -5,8 +5,8 @@ slug: changelog/v0.35.0
 
 * Breaking: Drop support for Node.js 18, now requires Node.js >= 20.9.0.
 
-* Breaking: Remove `install` script from `package.json` file.
-  Compiling from source is now opt-in via the `build` script.
+* Breaking: Remove `install` script.
+  If prebuilt binary is unavailable, [build from source](https://sharp.pixelplumbing.com/install/#building-from-source) manually.
 
 * Breaking: Lossy AVIF output is now tuned using SSIMULACRA2-based `iq` quality metrics.
 


### PR DESCRIPTION
Continuing from https://github.com/lovell/sharp/issues/4442#issuecomment-4717894434

## Assumptions

Users on `0.34` and below are facing a major update to `0.35` and above.

- Not all users know about life cycle scripts and how it works.
- Not all users know that libraries are shipped with prebuilt binaries.

## Goals

Make the changelog more actionable.

Guide users that building from source is possible but probably not needed. (as stated in the commit message)

Also, "now opt-in" is misleading because it gives an impression that compiling from source was automatic and mandatory.

If I understood correctly, it automatically compiled only if a compatible binary was not found:

> The slightly longer explanation is that if and only if prebuilt binaries are not available for the current platform and if and only if an emscripten development environment is detected then sharp will attempt to build WebAssembly binaries.

## Additional Suggestions

- Quote the actual error messages shown when package managers cannot resolve a prebuilt binary.
- Add a note on removing `sharp` from `onlyBuiltDependencies` or `allowBuilds`. This could help if a malicious update is released with life cycle scripts.