### PR TITLE
bound dilate and erode width to avoid mask-size overflow

### DIFF
--- a/lib/operation.mjs
+++ b/lib/operation.mjs
@@ -424,10 +424,10 @@ function blur (options) {
 function dilate (width) {
   if (!is.defined(width)) {
     this.options.dilateWidth = 1;
-  } else if (is.integer(width) && is.inRange(width, 1, 1000)) {
+  } else if (is.integer(width) && is.inRange(width, 1, 65536)) {
     this.options.dilateWidth = width;
   } else {
-    throw is.invalidParameterError('width', 'integer between 1 and 1000', width);
+    throw is.invalidParameterError('width', 'integer between 1 and 65536', width);
   }
   return this;
 }
@@ -447,10 +447,10 @@ function dilate (width) {
 function erode (width) {
   if (!is.defined(width)) {
     this.options.erodeWidth = 1;
-  } else if (is.integer(width) && is.inRange(width, 1, 1000)) {
+  } else if (is.integer(width) && is.inRange(width, 1, 65536)) {
     this.options.erodeWidth = width;
   } else {
-    throw is.invalidParameterError('width', 'integer between 1 and 1000', width);
+    throw is.invalidParameterError('width', 'integer between 1 and 65536', width);
   }
   return this;
 }

--- a/lib/operation.mjs
+++ b/lib/operation.mjs
@@ -424,10 +424,10 @@ function blur (options) {
 function dilate (width) {
   if (!is.defined(width)) {
     this.options.dilateWidth = 1;
-  } else if (is.integer(width) && width > 0) {
+  } else if (is.integer(width) && is.inRange(width, 1, 1000)) {
     this.options.dilateWidth = width;
   } else {
-    throw is.invalidParameterError('dilate', 'positive integer', dilate);
+    throw is.invalidParameterError('width', 'integer between 1 and 1000', width);
   }
   return this;
 }
@@ -447,10 +447,10 @@ function dilate (width) {
 function erode (width) {
   if (!is.defined(width)) {
     this.options.erodeWidth = 1;
-  } else if (is.integer(width) && width > 0) {
+  } else if (is.integer(width) && is.inRange(width, 1, 1000)) {
     this.options.erodeWidth = width;
   } else {
-    throw is.invalidParameterError('erode', 'positive integer', erode);
+    throw is.invalidParameterError('width', 'integer between 1 and 1000', width);
   }
   return this;
 }

--- a/test/unit/dilate.js
+++ b/test/unit/dilate.js
@@ -32,4 +32,11 @@ suite('Dilate', () => {
       sharp(fixtures.inputJpg).dilate(-1);
     });
   });
+
+  test('oversized dilation width is rejected', (t) => {
+    t.plan(1);
+    t.assert.throws(() => {
+      sharp(fixtures.inputJpg).dilate(2147483648);
+    });
+  });
 });

--- a/test/unit/erode.js
+++ b/test/unit/erode.js
@@ -32,4 +32,11 @@ suite('Erode', () => {
       sharp(fixtures.inputJpg).erode(-1);
     });
   });
+
+  test('oversized erosion width is rejected', (t) => {
+    t.plan(1);
+    t.assert.throws(() => {
+      sharp(fixtures.inputJpg).erode(2147483648);
+    });
+  });
 });


### PR DESCRIPTION
**Unbounded dilate/erode width overflows the mask size**

`dilate()` and `erode()` accept any positive integer, unlike the sibling `median()` which bounds its window to 1 to 1000, so an oversized width reaches the native `Dilate`/`Erode` where the structuring element is sized as `2 * width + 1` and passed to `new_matrix`; read through `AttrAsUint32` into an `int`, a width of `2^30` wraps that signed size negative and `2^32` narrows it to zero, silently dropping the operation. Bounded the width to match `median` so the value can no longer reach that calculation.