### PR TITLE
validate convolve kernel values are numbers

### DIFF
--- a/lib/operation.mjs
+++ b/lib/operation.mjs
@@ -706,7 +706,8 @@ function convolve (kernel) {
   if (!is.object(kernel) || !Array.isArray(kernel.kernel) ||
       !is.integer(kernel.width) || !is.integer(kernel.height) ||
       !is.inRange(kernel.width, 3, 1001) || !is.inRange(kernel.height, 3, 1001) ||
-      kernel.height * kernel.width !== kernel.kernel.length
+      kernel.height * kernel.width !== kernel.kernel.length ||
+      !kernel.kernel.every(is.number)
   ) {
     // must pass in a kernel
     throw new Error('Invalid convolution kernel');

--- a/test/unit/convolve.js
+++ b/test/unit/convolve.js
@@ -96,5 +96,25 @@ suite('Convolve', () => {
         });
       });
     });
+    test('non-numeric kernel value', (t) => {
+      t.plan(1);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg).convolve({
+          width: 3,
+          height: 3,
+          kernel: [1, 2, 3, 4, '5', 6, 7, 8, 9]
+        });
+      });
+    });
+    test('NaN kernel value', (t) => {
+      t.plan(1);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg).convolve({
+          width: 3,
+          height: 3,
+          kernel: [1, 2, 3, 4, NaN, 6, 7, 8, 9]
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
convolve validates the kernel width, height and that the flattened kernel array has the expected length, but never checks the entries themselves are numbers, unlike the sibling affine, linear and recomb operators which all guard their input with is.number. a NaN entry therefore passes straight through to the native convolution mask and produces a silently wrong (all-zero) result, whilst a string or null entry surfaces only the vague "A number was expected" from the native layer rather than the usual invalid-parameter error. the safer behaviour is to reject a malformed kernel up front, so this adds the same per-entry is.number check to the existing kernel validation, keeping the contract consistent with its siblings. the added tests cover the string and NaN cases, both of which slip through today.