### PR TITLE
bound clahe width and height to avoid signed overflow

### DIFF
--- a/lib/operation.mjs
+++ b/lib/operation.mjs
@@ -654,15 +654,15 @@ function normalize (options) {
  */
 function clahe (options) {
   if (is.plainObject(options)) {
-    if (is.integer(options.width) && options.width > 0) {
+    if (is.integer(options.width) && is.inRange(options.width, 1, 65536)) {
       this.options.claheWidth = options.width;
     } else {
-      throw is.invalidParameterError('width', 'integer greater than zero', options.width);
+      throw is.invalidParameterError('width', 'integer between 1 and 65536', options.width);
     }
-    if (is.integer(options.height) && options.height > 0) {
+    if (is.integer(options.height) && is.inRange(options.height, 1, 65536)) {
       this.options.claheHeight = options.height;
     } else {
-      throw is.invalidParameterError('height', 'integer greater than zero', options.height);
+      throw is.invalidParameterError('height', 'integer between 1 and 65536', options.height);
     }
     if (is.defined(options.maxSlope)) {
       if (is.integer(options.maxSlope) && is.inRange(options.maxSlope, 0, 100)) {

--- a/test/unit/clahe.js
+++ b/test/unit/clahe.js
@@ -89,12 +89,15 @@ suite('Clahe', () => {
   });
 
   test('invalid width', (t) => {
-    t.plan(4);
+    t.plan(5);
     t.assert.throws(() => {
       sharp(fixtures.inputJpgClahe).clahe({ width: 100.5, height: 100 });
     });
     t.assert.throws(() => {
       sharp(fixtures.inputJpgClahe).clahe({ width: -5, height: 100 });
+    });
+    t.assert.throws(() => {
+      sharp(fixtures.inputJpgClahe).clahe({ width: 2 ** 32, height: 100 });
     });
     t.assert.throws(() => {
       sharp(fixtures.inputJpgClahe).clahe({ width: true, height: 100 });
@@ -105,12 +108,15 @@ suite('Clahe', () => {
   });
 
   test('invalid height', (t) => {
-    t.plan(4);
+    t.plan(5);
     t.assert.throws(() => {
       sharp(fixtures.inputJpgClahe).clahe({ width: 100, height: 100.5 });
     });
     t.assert.throws(() => {
       sharp(fixtures.inputJpgClahe).clahe({ width: 100, height: -5 });
+    });
+    t.assert.throws(() => {
+      sharp(fixtures.inputJpgClahe).clahe({ width: 100, height: 2 ** 32 });
     });
     t.assert.throws(() => {
       sharp(fixtures.inputJpgClahe).clahe({ width: 100, height: true });


### PR DESCRIPTION
clahe() bounds width and height with only is.integer and a greater-than-zero check, unlike the sibling window operators median and dilate/erode which cap their size, so an oversized value reaches the native layer where claheWidth/claheHeight are read through AttrAsUint32 into an int and handed to hist_local. a width of 2^31 narrows that signed value negative and trips a GObject-CRITICAL warning, while 2^32 narrows to zero and the native guard then silently drops the equalisation that was requested. bound both to 1..65536 to match dilate and erode so the value can no longer reach that narrowing; the small search windows shown in the docs are unaffected.