### PR TITLE
bound trim margin to avoid signed overflow in extract size

### DIFF
--- a/docs/src/content/docs/api-resize.md
+++ b/docs/src/content/docs/api-resize.md
@@ -286,7 +286,7 @@ The `info` response Object will contain `trimOffsetLeft` and `trimOffsetTop` pro
 | [options.background] | <code>string</code> \| <code>Object</code> | <code>&quot;&#x27;top-left pixel&#x27;&quot;</code> | Background colour, parsed by the [color](https://www.npmjs.org/package/color) module, defaults to that of the top-left pixel. |
 | [options.threshold] | <code>number</code> | <code>10</code> | Allowed difference from the above colour, a positive number. |
 | [options.lineArt] | <code>boolean</code> | <code>false</code> | Does the input more closely resemble line art (e.g. vector) rather than being photographic? |
-| [options.margin] | <code>number</code> | <code>0</code> | Leave a margin around trimmed content, value is in pixels. |
+| [options.margin] | <code>number</code> | <code>0</code> | Leave a margin around trimmed content, integral number of pixels between 0 and 10000000. |
 
 **Example**  
 ```js

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1641,7 +1641,7 @@ declare namespace sharp {
         threshold?: number | undefined;
         /** Does the input more closely resemble line art (e.g. vector) rather than being photographic? (optional, default false) */
         lineArt?: boolean | undefined;
-        /** Leave a margin around trimmed content, value is in pixels. (optional, default 0) */
+        /** Leave a margin around trimmed content, integral number of pixels between 0 and 10000000. (optional, default 0) */
         margin?: number | undefined;
     }
 

--- a/lib/resize.mjs
+++ b/lib/resize.mjs
@@ -558,7 +558,7 @@ function extract (options) {
  * @param {string|Object} [options.background='top-left pixel'] - Background colour, parsed by the [color](https://www.npmjs.org/package/color) module, defaults to that of the top-left pixel.
  * @param {number} [options.threshold=10] - Allowed difference from the above colour, a positive number.
  * @param {boolean} [options.lineArt=false] - Does the input more closely resemble line art (e.g. vector) rather than being photographic?
- * @param {number} [options.margin=0] - Leave a margin around trimmed content, value is in pixels.
+ * @param {number} [options.margin=0] - Leave a margin around trimmed content, integral number of pixels between 0 and 10000000.
  * @returns {Sharp}
  * @throws {Error} Invalid parameters
  */
@@ -580,10 +580,10 @@ function trim (options) {
         this._setBooleanOption('trimLineArt', options.lineArt);
       }
       if (is.defined(options.margin)) {
-        if (is.integer(options.margin) && options.margin >= 0) {
+        if (is.integer(options.margin) && is.inRange(options.margin, 0, 10000000)) {
           this.options.trimMargin = options.margin;
         } else {
-          throw is.invalidParameterError('margin', 'positive integer', options.margin);
+          throw is.invalidParameterError('margin', 'integer between 0 and 10000000', options.margin);
         }
       }
     } else {

--- a/test/unit/trim.js
+++ b/test/unit/trim.js
@@ -219,6 +219,9 @@ suite('Trim borders', () => {
       },
       'Invalid margin': {
         margin: -1
+      },
+      'Oversized margin': {
+        margin: 2 ** 30
       }
     }).forEach(([description, parameter]) => {
       test(description, (t) => {


### PR DESCRIPTION
**Unbounded trim margin overflows the extract size**

The `margin` option is only checked with `is.integer` and `>= 0`, so it lacks the upper bound the sibling pixel dimensions now carry. It is read via `AttrAsUint32` and used in `Trim()` as `width + 2 * margin`, so a margin around 2^30 overflows the signed int into a negative extract width (a GLib-GObject-CRITICAL plus an `extract_area` failure), while a margin around 2^31 narrows to a negative int and the native `margin > 0` guard then silently drops it. I have bounded it to 0..10000000 (VIPS_MAX_COORD), which keeps the existing 9999999 clamp test green and should make the limit easier to reason about alongside the other dimensions.