### PR TITLE
reject non-finite numbers in is.number

### DIFF
--- a/lib/is.mjs
+++ b/lib/is.mjs
@@ -78,7 +78,7 @@ const string = (val) => typeof val === 'string' && val.length > 0;
  * Is this value a real number?
  * @private
  */
-const number = (val) => typeof val === 'number' && !Number.isNaN(val);
+const number = (val) => typeof val === 'number' && Number.isFinite(val);
 
 /**
  * Is this value an integer?

--- a/test/unit/affine.js
+++ b/test/unit/affine.js
@@ -73,6 +73,20 @@ suite('Affine transform', () => {
           .affine([[4, 4], [4, 4]], { ody: 'invalid ody type' });
       });
     });
+    test('Non-finite idx offset', (t) => {
+      t.plan(1);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg)
+          .affine([[4, 4], [4, 4]], { idx: Infinity });
+      });
+    });
+    test('Non-finite idy offset', (t) => {
+      t.plan(1);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg)
+          .affine([[4, 4], [4, 4]], { idy: -Infinity });
+      });
+    });
     test('Invalid interpolator', (t) => {
       t.plan(1);
       t.assert.throws(() => {


### PR DESCRIPTION
**Non-finite values treated as numbers**

`is.number` only excluded `NaN`, so `Infinity` and `-Infinity` passed as valid numbers and reached the native layer. The clearest symptom is `affine`: a non-finite `idx`/`idy`/`odx`/`ody` offset is set on the libvips `vips_affine` gdouble property, which rejects it with a `GLib-GObject-CRITICAL` and silently leaves the offset at 0, so the requested transform is quietly wrong rather than reported as invalid. Switching the check to `Number.isFinite` rejects these up front, which keeps the behaviour consistent for every numeric option that relies on the helper.