### PR TITLE
bound extract region to libvips coordinate limit

### DIFF
--- a/docs/src/content/docs/api-resize.md
+++ b/docs/src/content/docs/api-resize.md
@@ -236,10 +236,10 @@ Extract/crop a region of the image.
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>Object</code> | describes the region to extract using integral pixel values |
-| options.left | <code>number</code> | zero-indexed offset from left edge |
-| options.top | <code>number</code> | zero-indexed offset from top edge |
-| options.width | <code>number</code> | width of region to extract |
-| options.height | <code>number</code> | height of region to extract |
+| options.left | <code>number</code> | zero-indexed offset from left edge, an integer between 0 and 100000000 |
+| options.top | <code>number</code> | zero-indexed offset from top edge, an integer between 0 and 100000000 |
+| options.width | <code>number</code> | width of region to extract, an integer between 0 and 100000000 |
+| options.height | <code>number</code> | height of region to extract, an integer between 0 and 100000000 |
 
 **Example**  
 ```js

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1598,13 +1598,13 @@ declare namespace sharp {
     }
 
     interface Region {
-        /** zero-indexed offset from left edge */
+        /** zero-indexed offset from left edge, an integer between 0 and 100000000 */
         left: number;
-        /** zero-indexed offset from top edge */
+        /** zero-indexed offset from top edge, an integer between 0 and 100000000 */
         top: number;
-        /** dimension of extracted image */
+        /** dimension of extracted image, an integer between 0 and 100000000 */
         width: number;
-        /** dimension of extracted image */
+        /** dimension of extracted image, an integer between 0 and 100000000 */
         height: number;
     }
 

--- a/lib/resize.mjs
+++ b/lib/resize.mjs
@@ -471,10 +471,10 @@ function extend (extend) {
  *   });
  *
  * @param {Object} options - describes the region to extract using integral pixel values
- * @param {number} options.left - zero-indexed offset from left edge
- * @param {number} options.top - zero-indexed offset from top edge
- * @param {number} options.width - width of region to extract
- * @param {number} options.height - height of region to extract
+ * @param {number} options.left - zero-indexed offset from left edge, an integer between 0 and 100000000
+ * @param {number} options.top - zero-indexed offset from top edge, an integer between 0 and 100000000
+ * @param {number} options.width - width of region to extract, an integer between 0 and 100000000
+ * @param {number} options.height - height of region to extract, an integer between 0 and 100000000
  * @returns {Sharp}
  * @throws {Error} Invalid parameters
  */
@@ -485,10 +485,10 @@ function extract (options) {
   }
   ['left', 'top', 'width', 'height'].forEach(function (name) {
     const value = options[name];
-    if (is.integer(value) && value >= 0) {
+    if (is.integer(value) && is.inRange(value, 0, 100000000)) {
       this.options[name + (name === 'left' || name === 'top' ? 'Offset' : '') + suffix] = value;
     } else {
-      throw is.invalidParameterError(name, 'integer', value);
+      throw is.invalidParameterError(name, 'integer between 0 and 100000000', value);
     }
   }, this);
   // Ensure existing rotation occurs before pre-resize extraction

--- a/test/unit/extract.js
+++ b/test/unit/extract.js
@@ -282,6 +282,20 @@ suite('Partial image extraction', () => {
       });
     });
 
+    test('Oversized width', (t) => {
+      t.plan(1);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg).extract({ left: 10, top: 10, width: 100000001, height: 10 });
+      }, /Expected integer between 0 and 100000000 for width but received 100000001 of type number/);
+    });
+
+    test('Oversized left', (t) => {
+      t.plan(1);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg).extract({ left: 2 ** 31, top: 10, width: 10, height: 10 });
+      }, /Expected integer between 0 and 100000000 for left but received 2147483648 of type number/);
+    });
+
     test('Bad image area', async (t) => {
       t.plan(1);
       t.assert.rejects(


### PR DESCRIPTION
extract() validates left, top, width and height with is.integer(value) && value >= 0 but never caps them, so a coordinate above libvips' VIPS_MAX_COORD (100000000) reaches vips_extract_area and is rejected by the gint gobject property with a GLib-GObject-CRITICAL, surfacing only a misleading 'extract_area: parameter width not set' instead of a parameter error; a value of 2^31 narrows to a negative int the same way. the sibling pixel-dimension options (extend, trim margin, clahe, dilate, erode) were already bounded for this reason, so this brings extract into line by clamping each of the four to 0..100000000 in the validation layer. values up to the limit still pass through to vips unchanged, so a genuine out-of-image request keeps its existing 'bad extract area' behaviour.