### PR TITLE
validate background colour values are numbers

### DIFF
--- a/lib/colour.mjs
+++ b/lib/colour.mjs
@@ -146,12 +146,16 @@ function _getBackgroundColourOption (value) {
     (is.string(value) && value.length >= 3 && value.length <= 200)
   ) {
     const colour = color(value);
-    return [
+    const rgba = [
       colour.red(),
       colour.green(),
       colour.blue(),
       Math.round(colour.alpha() * 255)
     ];
+    if (!rgba.every(is.number)) {
+      throw is.invalidParameterError('background', 'valid colour', value);
+    }
+    return rgba;
   } else {
     throw is.invalidParameterError('background', 'object or string', value);
   }

--- a/lib/colour.mjs
+++ b/lib/colour.mjs
@@ -146,16 +146,16 @@ function _getBackgroundColourOption (value) {
     (is.string(value) && value.length >= 3 && value.length <= 200)
   ) {
     const colour = color(value);
-    const rgba = [
-      colour.red(),
-      colour.green(),
-      colour.blue(),
-      Math.round(colour.alpha() * 255)
-    ];
-    if (!rgba.every(is.number)) {
-      throw is.invalidParameterError('background', 'valid colour', value);
+    const red = colour.red();
+    const green = colour.green();
+    const blue = colour.blue();
+    const alpha = Math.round(colour.alpha() * 255);
+    for (const [channel, component] of [['red', red], ['green', green], ['blue', blue], ['alpha', alpha]]) {
+      if (!is.number(component)) {
+        throw is.invalidParameterError(`background.${channel}`, 'number', component);
+      }
     }
-    return rgba;
+    return [red, green, blue, alpha];
   } else {
     throw is.invalidParameterError('background', 'object or string', value);
   }

--- a/test/unit/tint.js
+++ b/test/unit/tint.js
@@ -106,15 +106,19 @@ suite('Tint', () => {
     );
   });
 
-  test('non-numeric colour component fails', (t) => {
-    t.plan(2);
+  test('non-numeric colour component fails, identifying the channel', (t) => {
+    t.plan(3);
     t.assert.throws(
       () => sharp().tint({ r: 'fail', g: 0, b: 0 }),
-      /Expected valid colour for background but received \[object Object\] of type object/
+      /Expected number for background\.red but received NaN of type number/
     );
     t.assert.throws(
       () => sharp().tint({ r: NaN, g: 0, b: 0 }),
-      /Expected valid colour for background but received \[object Object\] of type object/
+      /Expected number for background\.red but received NaN of type number/
+    );
+    t.assert.throws(
+      () => sharp().tint({ r: 0, g: 0, b: 'fail' }),
+      /Expected number for background\.blue but received NaN of type number/
     );
   });
 });

--- a/test/unit/tint.js
+++ b/test/unit/tint.js
@@ -105,4 +105,16 @@ suite('Tint', () => {
       () => fixtures.assertMaxColourDistance(output, fixtures.expected('tint-cmyk.jpg'), maxDistance)
     );
   });
+
+  test('non-numeric colour component fails', (t) => {
+    t.plan(2);
+    t.assert.throws(
+      () => sharp().tint({ r: 'fail', g: 0, b: 0 }),
+      /Expected valid colour for background but received \[object Object\] of type object/
+    );
+    t.assert.throws(
+      () => sharp().tint({ r: NaN, g: 0, b: 0 }),
+      /Expected valid colour for background but received \[object Object\] of type object/
+    );
+  });
 });


### PR DESCRIPTION
**Non-numeric colour components reach libvips unchecked**

A background object with a non-numeric component such as `{ r: 'x', g: 0, b: 0 }` is parsed into an RGBA array where that channel becomes `NaN`, which `_getBackgroundColourOption` returns without checking, so it reaches the native layer and the result is silently wrong rather than rejected. The check sits in this shared helper because every background option (tint, flatten, extend, rotate, create, join, etc.) routes through it, matching the strictness the direct numeric options already apply.