### PR TITLE
bound create and raw input dimensions to coordinate limit

### DIFF
--- a/lib/input.mjs
+++ b/lib/input.mjs
@@ -181,8 +181,8 @@ function _createInputDescriptor (input, inputOptions, containerOptions) {
     if (is.defined(inputOptions.raw)) {
       if (
         is.object(inputOptions.raw) &&
-        is.integer(inputOptions.raw.width) && inputOptions.raw.width > 0 &&
-        is.integer(inputOptions.raw.height) && inputOptions.raw.height > 0 &&
+        is.integer(inputOptions.raw.width) && is.inRange(inputOptions.raw.width, 1, 100000000) &&
+        is.integer(inputOptions.raw.height) && is.inRange(inputOptions.raw.height, 1, 100000000) &&
         is.integer(inputOptions.raw.channels) && is.inRange(inputOptions.raw.channels, 1, 4)
       ) {
         inputDescriptor.rawWidth = inputOptions.raw.width;
@@ -329,8 +329,8 @@ function _createInputDescriptor (input, inputOptions, containerOptions) {
     if (is.defined(inputOptions.create)) {
       if (
         is.object(inputOptions.create) &&
-        is.integer(inputOptions.create.width) && inputOptions.create.width > 0 &&
-        is.integer(inputOptions.create.height) && inputOptions.create.height > 0 &&
+        is.integer(inputOptions.create.width) && is.inRange(inputOptions.create.width, 1, 100000000) &&
+        is.integer(inputOptions.create.height) && is.inRange(inputOptions.create.height, 1, 100000000) &&
         is.integer(inputOptions.create.channels)
       ) {
         inputDescriptor.createWidth = inputOptions.create.width;

--- a/test/unit/io.js
+++ b/test/unit/io.js
@@ -1158,6 +1158,30 @@ suite('Input/output', () => {
         sharp({ create });
       });
     });
+    test('Width beyond pixel limit', (t) => {
+      t.plan(1);
+      const create = {
+        width: 100000001,
+        height: 10,
+        channels: 3,
+        background: { r: 0, g: 0, b: 0 }
+      };
+      t.assert.throws(() => {
+        sharp({ create });
+      });
+    });
+    test('Height beyond pixel limit', (t) => {
+      t.plan(1);
+      const create = {
+        width: 10,
+        height: 100000001,
+        channels: 3,
+        background: { r: 0, g: 0, b: 0 }
+      };
+      t.assert.throws(() => {
+        sharp({ create });
+      });
+    });
   });
 
   test('Queue length change events', async (t) => {

--- a/test/unit/raw.js
+++ b/test/unit/raw.js
@@ -61,6 +61,20 @@ suite('Raw pixel data', () => {
       });
     });
 
+    test('Width beyond pixel limit', (t) => {
+      t.plan(1);
+      t.assert.throws(() => {
+        sharp({ raw: { width: 100000001, height: 1, channels: 4 } });
+      });
+    });
+
+    test('Height beyond pixel limit', (t) => {
+      t.plan(1);
+      t.assert.throws(() => {
+        sharp({ raw: { width: 1, height: 100000001, channels: 4 } });
+      });
+    });
+
     test('Invalid premultiplied', (t) => {
       t.plan(1);
       t.assert.throws(


### PR DESCRIPTION
**Unbounded create and raw input dimensions**

`create.width`/`height` and `raw.width`/`height` in `_createInputDescriptor` were validated only as `> 0`, so a dimension above the libvips coordinate limit reaches the `gint` width/height property and is silently dropped: 100000001 leaves a `GLib-GObject-CRITICAL` and a 1px fallback image, and 2147483648 narrows to a negative size. Bounded all four to 1-100000000 to match the `text.width`/`text.height` check already in the same function, so an oversized dimension now fails validation up front rather than producing a wrong-sized result. This also keeps the input-descriptor checks consistent with the other dimension options.