### PR TITLE
Reject ragged matrices in recomb and affine

### DIFF
--- a/lib/operation.mjs
+++ b/lib/operation.mjs
@@ -178,7 +178,13 @@ function flop (flop) {
  * @throws {Error} Invalid parameters
  */
 function affine (matrix, options) {
-  const flatMatrix = Array.isArray(matrix) ? [].concat(...matrix) : [];
+  const isValidShape = Array.isArray(matrix) && (
+    // 1x4 array of numbers
+    (matrix.length === 4 && matrix.every(is.number)) ||
+    // 2x2 array of arrays of numbers
+    (matrix.length === 2 && matrix.every((row) => Array.isArray(row) && row.length === 2))
+  );
+  const flatMatrix = isValidShape ? matrix.flat() : [];
   if (flatMatrix.length === 4 && flatMatrix.every(is.number)) {
     this.options.affineMatrix = flatMatrix;
   } else {
@@ -860,13 +866,14 @@ function recomb (inputMatrix) {
   if (!Array.isArray(inputMatrix)) {
     throw is.invalidParameterError('inputMatrix', 'array', inputMatrix);
   }
-  if (inputMatrix.length !== 3 && inputMatrix.length !== 4) {
-    throw is.invalidParameterError('inputMatrix', '3x3 or 4x4 array', inputMatrix.length);
+  const dimensions = inputMatrix.length;
+  if (dimensions !== 3 && dimensions !== 4) {
+    throw is.invalidParameterError('inputMatrix', '3x3 or 4x4 array', dimensions);
+  }
+  if (!inputMatrix.every((row) => Array.isArray(row) && row.length === dimensions)) {
+    throw is.invalidParameterError('inputMatrix', `array of ${dimensions} arrays of length ${dimensions}`, inputMatrix);
   }
   const recombMatrix = inputMatrix.flat();
-  if (recombMatrix.length !== 9 && recombMatrix.length !== 16) {
-    throw is.invalidParameterError('inputMatrix', 'cardinality of 9 or 16', recombMatrix.length);
-  }
   if (!recombMatrix.every(is.number)) {
     throw is.invalidParameterError('inputMatrix', 'array of numbers', recombMatrix);
   }

--- a/test/unit/affine.js
+++ b/test/unit/affine.js
@@ -31,6 +31,17 @@ suite('Affine transform', () => {
           .affine([[123, 123], [null, 123]]);
       });
     });
+    test('Ragged matrix flattening to a length of four', (t) => {
+      t.plan(2);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg)
+          .affine([[1, 2, 3], [4]]);
+      }, /Expected 1x4 or 2x2 array for matrix/);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg)
+          .affine([[1], [2], [3], [4]]);
+      }, /Expected 1x4 or 2x2 array for matrix/);
+    });
     test('Invalid options parameter type', (t) => {
       t.plan(1);
       t.assert.throws(() => {

--- a/test/unit/recomb.js
+++ b/test/unit/recomb.js
@@ -164,6 +164,15 @@ suite('Recomb', () => {
         sharp(fixtures.inputJpg).recomb([[1, 2, 3, 4], [5, 6, 7, 8]]);
       });
     });
+    test('ragged rows summing to a valid cardinality', (t) => {
+      t.plan(2);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg).recomb([[1, 2, 3, 4, 5], [6, 7], [8, 9]]);
+      }, /Expected array of 3 arrays of length 3 for inputMatrix/);
+      t.assert.throws(() => {
+        sharp(fixtures.inputJpg).recomb([[1, 2, 3, 4, 5], [6, 7, 8, 9], [10, 11, 12], [13, 14, 15, 16]]);
+      }, /Expected array of 4 arrays of length 4 for inputMatrix/);
+    });
     test('non-numeric entries', (t) => {
       t.plan(1);
       t.assert.throws(() => {


### PR DESCRIPTION
`recomb()` and `affine()` flatten the supplied matrix and validate only the *total* element count. A non-rectangular nested array whose values happen to flatten to a valid cardinality is therefore accepted and applied with the wrong shape instead of being rejected:

```js
sharp(input).recomb([[1, 2, 3, 4, 5], [6, 7], [8, 9]]);   // flat length 9 -> silently treated as 3x3
sharp(input).affine([[1, 2, 3], [4]]);                    // flat length 4 -> silently treated as 2x2
```

This validates that every row is an array of the expected length before flattening, so malformed matrices throw `Invalid parameter` as documented ("3x3 or 4x4" / "1x4 or 2x2"). The existing `recomb` "incorrect sub size" test already established the intent to reject non-rectangular matrices; this closes the gap where the row lengths cancel out.

Added unit tests for both that fail without the change. `npm run lint-js` (biome) clean.