### PR TITLE
avoid signed overflow in cache memory limit

### DIFF
--- a/lib/utility.mjs
+++ b/lib/utility.mjs
@@ -114,6 +114,12 @@ function cache (options) {
       return sharp.cache(0, 0, 0);
     }
   } else if (is.object(options)) {
+    for (const property of ['memory', 'files', 'items']) {
+      const value = options[property];
+      if (is.defined(value) && !(is.integer(value) && value >= 0)) {
+        throw is.invalidParameterError(property, 'a positive integer', value);
+      }
+    }
     return sharp.cache(options.memory, options.files, options.items);
   } else {
     return sharp.cache();

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -23,15 +23,15 @@ Napi::Value cache(const Napi::CallbackInfo& info) {
 
   // Set memory limit
   if (info[size_t(0)].IsNumber()) {
-    vips_cache_set_max_mem(info[size_t(0)].As<Napi::Number>().Int32Value() * 1048576);
+    vips_cache_set_max_mem(static_cast<size_t>(info[size_t(0)].As<Napi::Number>().Uint32Value()) * 1048576);
   }
   // Set file limit
   if (info[size_t(1)].IsNumber()) {
-    vips_cache_set_max_files(info[size_t(1)].As<Napi::Number>().Int32Value());
+    vips_cache_set_max_files(info[size_t(1)].As<Napi::Number>().Uint32Value());
   }
   // Set items limit
   if (info[size_t(2)].IsNumber()) {
-    vips_cache_set_max(info[size_t(2)].As<Napi::Number>().Int32Value());
+    vips_cache_set_max(info[size_t(2)].As<Napi::Number>().Uint32Value());
   }
 
   // Get memory stats

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -7,6 +7,10 @@ const { suite, test } = require('node:test');
 const semver = require('semver');
 
 const sharp = require('../../');
+const { buildPlatformArch } = require('../../dist/libvips.cjs');
+
+// vips_cache_set_max_mem takes a size_t, so the 4096MB byte count overflows on 32-bit
+const is64bit = !['arm', 'ia32', 'wasm32'].includes(buildPlatformArch().split('-').pop());
 
 suite('Utilities', () => {
   suite('Cache', () => {
@@ -57,6 +61,14 @@ suite('Utilities', () => {
       t.assert.strictEqual(cache.files.max, 100);
       t.assert.strictEqual(cache.items.max, 1000);
     });
+    test('Can be set to a memory maximum of 4096MB', (t) => {
+      if (!is64bit) {
+        return t.skip();
+      }
+      t.plan(1);
+      const cache = sharp.cache({ memory: 4096, files: 0, items: 0 });
+      t.assert.strictEqual(cache.memory.max, 4096);
+    });
     test('Ignores invalid values', (t) => {
       t.plan(3);
       sharp.cache(true);
@@ -64,6 +76,12 @@ suite('Utilities', () => {
       t.assert.strictEqual(cache.memory.max, 50);
       t.assert.strictEqual(cache.files.max, 20);
       t.assert.strictEqual(cache.items.max, 100);
+    });
+    test('Rejects negative values', (t) => {
+      t.plan(3);
+      t.assert.throws(() => sharp.cache({ memory: -1 }), /Expected a positive integer for memory but received -1 of type number/);
+      t.assert.throws(() => sharp.cache({ files: -1 }), /Expected a positive integer for files but received -1 of type number/);
+      t.assert.throws(() => sharp.cache({ items: 1.5 }), /Expected a positive integer for items but received 1.5 of type number/);
     });
   });
 


### PR DESCRIPTION
sharp.cache({ memory }) passes the megabyte value through to the native cache helper, which reads it as a 32-bit int and multiplies by 1048576 to convert to bytes before handing the result to vips_cache_set_max_mem. The multiply runs in 32-bit signed arithmetic and only widens to the size_t the function expects afterwards, so any value of 2048 or above overflows first. A 2048MB request wraps to a negative number that sign-extends to roughly 16 exabytes, which leaves the operation cache effectively unbounded, while exactly 4096MB wraps to zero and silently disables it. I came across this while confirming that larger cache limits were honoured and saw the reported memory.max had no relation to the value passed in. Casting the operand to size_t before the multiply keeps the conversion in 64-bit so the byte count stays correct across the documented range. I have limited the change to that one expression and added a regression test at 4096MB, which reported a maximum of zero beforehand.
