### PR TITLE
bound composite left and top to coordinate limit

### DIFF
--- a/docs/src/content/docs/api-composite.md
+++ b/docs/src/content/docs/api-composite.md
@@ -54,8 +54,8 @@ and https://www.cairographics.org/operators/
 | [images[].autoOrient] | <code>Boolean</code> | <code>false</code> | set to true to use EXIF orientation data, if present, to orient the image. |
 | [images[].blend] | <code>String</code> | <code>&#x27;over&#x27;</code> | how to blend this image with the image below. |
 | [images[].gravity] | <code>String</code> | <code>&#x27;centre&#x27;</code> | gravity at which to place the overlay. |
-| [images[].top] | <code>Number</code> |  | the pixel offset from the top edge. |
-| [images[].left] | <code>Number</code> |  | the pixel offset from the left edge. |
+| [images[].top] | <code>Number</code> |  | the pixel offset from the top edge, an integer between -100000000 and 100000000. |
+| [images[].left] | <code>Number</code> |  | the pixel offset from the left edge, an integer between -100000000 and 100000000. |
 | [images[].tile] | <code>Boolean</code> | <code>false</code> | set to true to repeat the overlay image across the entire image with the given `gravity`. |
 | [images[].premultiplied] | <code>Boolean</code> | <code>false</code> | set to true to avoid premultiplying the image below. Equivalent to the `--premultiplied` vips option. |
 | [images[].density] | <code>Number</code> | <code>72</code> | number representing the DPI for vector overlay image. |

--- a/lib/composite.mjs
+++ b/lib/composite.mjs
@@ -113,8 +113,8 @@ const blend = {
  * @param {Boolean} [images[].autoOrient=false] - set to true to use EXIF orientation data, if present, to orient the image.
  * @param {String} [images[].blend='over'] - how to blend this image with the image below.
  * @param {String} [images[].gravity='centre'] - gravity at which to place the overlay.
- * @param {Number} [images[].top] - the pixel offset from the top edge.
- * @param {Number} [images[].left] - the pixel offset from the left edge.
+ * @param {Number} [images[].top] - the pixel offset from the top edge, an integer between -100000000 and 100000000.
+ * @param {Number} [images[].left] - the pixel offset from the left edge, an integer between -100000000 and 100000000.
  * @param {Boolean} [images[].tile=false] - set to true to repeat the overlay image across the entire image with the given `gravity`.
  * @param {Boolean} [images[].premultiplied=false] - set to true to avoid premultiplying the image below. Equivalent to the `--premultiplied` vips option.
  * @param {Number} [images[].density=72] - number representing the DPI for vector overlay image.
@@ -163,17 +163,17 @@ function composite (images) {
       }
     }
     if (is.defined(image.left)) {
-      if (is.integer(image.left)) {
+      if (is.integer(image.left) && is.inRange(image.left, -100000000, 100000000)) {
         composite.left = image.left;
       } else {
-        throw is.invalidParameterError('left', 'integer', image.left);
+        throw is.invalidParameterError('left', 'integer between -100000000 and 100000000', image.left);
       }
     }
     if (is.defined(image.top)) {
-      if (is.integer(image.top)) {
+      if (is.integer(image.top) && is.inRange(image.top, -100000000, 100000000)) {
         composite.top = image.top;
       } else {
-        throw is.invalidParameterError('top', 'integer', image.top);
+        throw is.invalidParameterError('top', 'integer between -100000000 and 100000000', image.top);
       }
     }
     if (is.defined(image.top) !== is.defined(image.left)) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1693,9 +1693,9 @@ declare namespace sharp {
         blend?: Blend | undefined;
         /** gravity at which to place the overlay. (optional, default 'centre') */
         gravity?: Gravity | undefined;
-        /** the pixel offset from the top edge. */
+        /** the pixel offset from the top edge, an integer between -100000000 and 100000000. */
         top?: number | undefined;
-        /** the pixel offset from the left edge. */
+        /** the pixel offset from the left edge, an integer between -100000000 and 100000000. */
         left?: number | undefined;
         /** set to true to repeat the overlay image across the entire image with the given  gravity. (optional, default false) */
         tile?: boolean | undefined;

--- a/test/unit/composite.js
+++ b/test/unit/composite.js
@@ -400,29 +400,35 @@ suite('composite', () => {
     });
 
     test('invalid left', (t) => {
-      t.plan(3);
+      t.plan(4);
       t.assert.throws(() => {
         sharp().composite([{ input: 'test', left: 0.5 }]);
-      }, /Expected integer for left but received 0.5 of type number/);
+      }, /Expected integer between -100000000 and 100000000 for left but received 0.5 of type number/);
       t.assert.throws(() => {
         sharp().composite([{ input: 'test', left: 'invalid' }]);
-      }, /Expected integer for left but received invalid of type string/);
+      }, /Expected integer between -100000000 and 100000000 for left but received invalid of type string/);
       t.assert.throws(() => {
         sharp().composite([{ input: 'test', left: 'invalid', top: 10 }]);
-      }, /Expected integer for left but received invalid of type string/);
+      }, /Expected integer between -100000000 and 100000000 for left but received invalid of type string/);
+      t.assert.throws(() => {
+        sharp().composite([{ input: 'test', left: 4294967301, top: 10 }]);
+      }, /Expected integer between -100000000 and 100000000 for left but received 4294967301 of type number/);
     });
 
     test('invalid top', (t) => {
-      t.plan(3);
+      t.plan(4);
       t.assert.throws(() => {
         sharp().composite([{ input: 'test', top: 0.5 }]);
-      }, /Expected integer for top but received 0.5 of type number/);
+      }, /Expected integer between -100000000 and 100000000 for top but received 0.5 of type number/);
       t.assert.throws(() => {
         sharp().composite([{ input: 'test', top: 'invalid' }]);
-      }, /Expected integer for top but received invalid of type string/);
+      }, /Expected integer between -100000000 and 100000000 for top but received invalid of type string/);
       t.assert.throws(() => {
         sharp().composite([{ input: 'test', top: 'invalid', left: 10 }]);
-      }, /Expected integer for top but received invalid of type string/);
+      }, /Expected integer between -100000000 and 100000000 for top but received invalid of type string/);
+      t.assert.throws(() => {
+        sharp().composite([{ input: 'test', top: 4294967301, left: 10 }]);
+      }, /Expected integer between -100000000 and 100000000 for top but received 4294967301 of type number/);
     });
 
     test('left but no top', (t) => {


### PR DESCRIPTION
**Composite offsets truncate to 32-bit in native**

The per-overlay `left` and `top` are validated with `is.integer` only, so any safe integer up to 2^53 is accepted, but `AttrAsInt32` narrows them before they reach the `vips_composite` position arrays. An offset such as `left: 4294967301` silently becomes `5`, placing the overlay somewhere other than requested, while `2147483648` wraps negative and the overlay is dropped off-canvas with no error.

Bounded both to -100000000..100000000, the same coordinate limit the sibling `extract`/`create`/`raw` options already use. Negative offsets stay valid, so partly off-edge overlays are unaffected; only values that would truncate are now rejected up front. Regression cases added alongside the existing invalid `left`/`top` tests.
