### PR TITLE
honour the tiff.subifd input option

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -118,7 +118,7 @@ namespace sharp {
       descriptor->openSlideLevel = AttrAsUint32(input, "openSlideLevel");
     }
     // subIFD (OME-TIFF)
-    if (HasAttr(input, "subifd")) {
+    if (HasAttr(input, "tiffSubifd")) {
       descriptor->tiffSubifd = AttrAsInt32(input, "tiffSubifd");
     }
     // // PDF background color

--- a/test/unit/io.js
+++ b/test/unit/io.js
@@ -1054,6 +1054,18 @@ suite('Input/output', () => {
         /Expected integer between -1 and 100000 for subifd but received 1.2 of type number/
       );
     });
+    test('tiff.subifd is applied when decoding', async (t) => {
+      t.plan(2);
+      // The default main IFD (-1) decodes as usual
+      const { width } = await sharp(fixtures.inputTiffUncompressed, { tiff: { subifd: -1 } }).metadata();
+      t.assert.strictEqual(width, 246);
+      // Requesting a sub-IFD reaches the loader, so a file without sub-IFDs
+      // now fails rather than silently decoding the main image
+      await t.assert.rejects(
+        () => sharp(fixtures.inputTiffUncompressed, { tiff: { subifd: 0 } }).toBuffer(),
+        /SUBIFD/
+      );
+    });
     test('Valid pdf.background property (string)', (t) => {
       t.plan(1);
       sharp({ pdf: { background: '#00ff00' } });


### PR DESCRIPTION
**tiff.subifd is silently ignored**

The native input descriptor guards the sub-IFD read with `HasAttr(input, "subifd")`, but `lib/input.mjs` only ever sets the `tiffSubifd` property, so the guard never matches and the value keeps its `-1` default on the way to the libvips loader. Matched the guard to the read (which already uses `tiffSubifd`) and added a regression test.