### PR TITLE
set n-pages in SetAnimationProperties to match pages written

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -711,9 +711,12 @@ namespace sharp {
     bool hasDelay = !delay.empty();
     VImage copy = image.copy();
 
-    // Only set page-height if we have more than one page, or this could
-    // accidentally turn into an animated image later.
-    if (nPages > 1) copy.set(VIPS_META_PAGE_HEIGHT, pageHeight);
+    // Only set page-height and n-pages if we have more than one page, or this
+    // could accidentally turn into an animated image later.
+    if (nPages > 1) {
+      copy.set(VIPS_META_PAGE_HEIGHT, pageHeight);
+      copy.set(VIPS_META_N_PAGES, nPages);
+    }
     if (hasDelay) {
       if (delay.size() == 1) {
         // We have just one delay, repeat that value for all frames.

--- a/test/unit/gif.js
+++ b/test/unit/gif.js
@@ -64,6 +64,14 @@ suite('GIF input', () => {
     t.assert.strictEqual(80, info.pageHeight);
   });
 
+  test('Animated GIF limited to fewer pages than the input', async (t) => {
+    t.plan(3);
+    const { info } = await sharp(fixtures.inputGifAnimated, { pages: 2 }).toBuffer({ resolveWithObject: true });
+    t.assert.strictEqual(160, info.height);
+    t.assert.strictEqual(80, info.pageHeight);
+    t.assert.strictEqual(2, info.pages);
+  });
+
   test('GIF with reduced colours, no dither, low effort reduces file size', async (t) => {
     t.plan(1);
     const original = await sharp(fixtures.inputJpg)


### PR DESCRIPTION
**Stale n-pages on animated output**

SetAnimationProperties sets page-height on the output image but leaves n-pages at the value the loader recorded for the input file, so `info.pages` reports the source page count rather than the number actually written: `sharp(animated, { pages: 2 })` reports 30 alongside a height of 160 and a pageHeight of 80, and the same stale count is persisted to `v` output. Setting it beside page-height keeps the pair consistent, which is what the raw/create input paths and the animated join already do.
