### PR TITLE
Document that autoOrient handles only EXIF Orientation

### DIFF
--- a/docs/src/content/docs/api-operation.md
+++ b/docs/src/content/docs/api-operation.md
@@ -56,6 +56,10 @@ const resizeThenRotate = await sharp(input)
 Auto-orient based on the EXIF `Orientation` tag, then remove the tag.
 Mirroring is supported and may infer the use of a flip operation.
 
+Only the EXIF `Orientation` tag is considered; orientation carried in other
+places, such as an XMP `tiff:Orientation` element, is left untouched and
+remains the responsibility of the consumer.
+
 Previous or subsequent use of `rotate(angle)` and either `flip()` or `flop()`
 will logically occur after auto-orientation, regardless of call order.
 

--- a/lib/operation.mjs
+++ b/lib/operation.mjs
@@ -78,6 +78,10 @@ function rotate (angle, options) {
  * Auto-orient based on the EXIF `Orientation` tag, then remove the tag.
  * Mirroring is supported and may infer the use of a flip operation.
  *
+ * Only the EXIF `Orientation` tag is considered; orientation carried in other
+ * places, such as an XMP `tiff:Orientation` element, is left untouched and
+ * remains the responsibility of the consumer.
+ *
  * Previous or subsequent use of `rotate(angle)` and either `flip()` or `flop()`
  * will logically occur after auto-orientation, regardless of call order.
  *


### PR DESCRIPTION
As discussed in #4585, the preferred resolution is to document that `autoOrient()` handles only the EXIF `Orientation` tag — managing values inside XML strings (e.g. an XMP `tiff:Orientation` element) adds too much complexity and is left to the consumer.

This PR adds a short note to that effect in the `autoOrient()` JSDoc (`lib/operation.mjs`) and its generated docs page (`docs/src/content/docs/api-operation.md`).

No behavioural change.

Resolves #4585.