### PR TITLE
Docs: add security guidance for untrusted input

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -71,6 +71,7 @@ export default defineConfig({
           ]
         },
         { label: 'Performance', slug: 'performance' },
+        { label: 'Security', slug: 'security' },
         {
           label: 'Changelog',
           collapsed: true,

--- a/docs/src/content/docs/security.md
+++ b/docs/src/content/docs/security.md
@@ -1,0 +1,28 @@
+---
+title: Security
+---
+
+The default settings help protect against malformed or unusually large input,
+but applications that process untrusted images should also enforce their own resource limits.
+
+## Untrusted input
+
+- Keep the default `failOn: 'warning'`, `limitInputPixels`, `limitInputChannels`
+  and `unlimited: false` constructor options. Set lower limits when the application
+  accepts a smaller range of dimensions or channels.
+- When downloading an image, validate the resolved destination initially and after each
+  redirect, and enforce time and byte limits while streaming before data reaches `sharp`.
+- Use [`timeout`](/api-output/#timeout) to limit active processing after libvips opens
+  the input. Apply an outer job deadline and enforce memory and CPU limits at the process
+  or container level. Pixel limits rely on image metadata and do not replace runtime limits.
+- Restrict the available input loaders with [`block`](/api-utility/#block) and
+  [`unblock`](/api-utility/#unblock) when only specific formats are required.
+- Use the latest release, which is the only version covered by the
+  [security policy](https://github.com/lovell/sharp/security/policy).
+
+## Trusted input
+
+For images generated and controlled by the application, individual safety settings
+can be relaxed when their cost or format restrictions are unnecessary. Change only
+the specific `limitInputPixels`, `limitInputChannels` or `unlimited` setting required
+for the use case and retain the others.


### PR DESCRIPTION
I use sharp to process untrusted remote images in an open-source social preview generator. This documents the relevant constructor defaults, download and runtime limits, loader restrictions, and when individual settings can be relaxed for trusted input.

Closes #4098.