### PR TITLE
Prevent TypeError when module load error has no code

### DIFF
--- a/lib/sharp.mjs
+++ b/lib/sharp.mjs
@@ -112,8 +112,8 @@ if (!sharp) {
 
   const help = [`Could not load the "sharp" module using the ${runtimePlatform} runtime`];
   errors.forEach((err) => {
-    if (!err.code.endsWith("MODULE_NOT_FOUND")) {
-      help.push(`${err.code}: ${err.message}`);
+    if (!err.code?.endsWith("MODULE_NOT_FOUND")) {
+      help.push(err.code ? `${err.code}: ${err.message}` : err.message);
     }
   });
   const messages = errors.map((err) => err.message).join(" ");


### PR DESCRIPTION
When every attempt to load the native binding fails, the loop that builds the help message assumes each collected error carries a string `code`. A `CompileError` from a failed wasm32 instantiation has none, so `err.code.endsWith` throws a `TypeError` and the real reason for the failure never reaches the user.

The load path is import-time code inside a `node:coverage disable` block, so I couldn't see a way to cover this with a unit test without extracting the help-message builder into its own exported function. Happy to do that if you'd prefer.

Fixes #4592
